### PR TITLE
fix: disabled button doesn't change background on hover

### DIFF
--- a/ui/button/src/Button.tsx
+++ b/ui/button/src/Button.tsx
@@ -22,6 +22,11 @@ export const Button = styled("button", {
     color: "$onDisabled",
     backgroundColor: "$colors$disabled",
     borderColor: "$colors$onDisabled",
+    "@hover": {
+      "&:hover": {
+        backgroundColor: "$colors$disabled",
+      },
+    },
   },
 
   variants: {


### PR DESCRIPTION
## What I did

When hovering over disabled button background shouldn't change

