### PR TITLE
fix: removed pointer events from Label in InputText and InputTextarea

### DIFF
--- a/ui/input-text/src/InputText.tsx
+++ b/ui/input-text/src/InputText.tsx
@@ -86,6 +86,7 @@ const TextInputLabel = styled(InputLabel, {
   insetBlockStart: "0",
   insetInlineStart: "$050",
   position: "absolute",
+  pointerEvents: "none",
   transform: `translateY(${theme.space["100"]})`,
   variants: {
     isFloating: {

--- a/ui/input-textarea/src/InputTextarea.tsx
+++ b/ui/input-textarea/src/InputTextarea.tsx
@@ -36,6 +36,7 @@ const InputTextareaCSS = Theme.css({
 const TextAreaLabel = Theme.styled(InputLabel, {
   insetBlockStart: "$050",
   insetInlineStart: "$050",
+  pointerEvents: "none",
   position: "absolute",
   variants: {
     isFloating: {


### PR DESCRIPTION
This PR removes pointer events from floating labels in inputs. Allowing clicking on the label to focus the input
