### PR TITLE
fix: updates sharedInputStyles text color

### DIFF
--- a/ui/input-shared/src/InputShared.tsx
+++ b/ui/input-shared/src/InputShared.tsx
@@ -7,6 +7,7 @@ export const sharedInputStyles = {
   borderStyle: "solid",
   borderWidth: "1px",
   backgroundColor: theme.colors.secondary,
+  color: theme.colors.primary,
   fontFamily: theme.fonts.meta,
   fontSize: theme.fontSizes["100"],
   fontWeight: theme.fontWeights.light,


### PR DESCRIPTION
set text color to "primary" to support inputs in dark mode
<img width="192" alt="image" src="https://user-images.githubusercontent.com/102534985/167710857-7d333e38-e059-4a1f-967e-9f5966cb092f.png">
<img width="194" alt="image" src="https://user-images.githubusercontent.com/102534985/167710914-810a5cee-430b-4772-944c-6a386446a816.png">
<img width="233" alt="image" src="https://user-images.githubusercontent.com/102534985/167710962-000dec1a-c0dd-4c64-b049-78f760d80c6a.png">
