### PR TITLE
fix: changed icon imports to support ESM compilation

### DIFF
--- a/ui/alert-banner/src/AlertBanner.tsx
+++ b/ui/alert-banner/src/AlertBanner.tsx
@@ -7,11 +7,13 @@ import { AppBar } from "@washingtonpost/wpds-app-bar";
 
 import type * as WPDS from "@washingtonpost/wpds-theme";
 
-import Error from "@washingtonpost/wpds-assets/asset/error";
-import Success from "@washingtonpost/wpds-assets/asset/success";
-import Warning from "@washingtonpost/wpds-assets/asset/warning";
-import Information from "@washingtonpost/wpds-assets/asset/info";
-import Close from "@washingtonpost/wpds-assets/asset/close";
+import {
+  Error,
+  Success,
+  Warning,
+  Info as Information,
+  Close,
+} from "@washingtonpost/wpds-assets";
 
 const StyledAlertBannerTrigger = styled(Button, {
   alignSelf: "flex-start",

--- a/ui/checkbox/src/Checkbox.tsx
+++ b/ui/checkbox/src/Checkbox.tsx
@@ -2,8 +2,7 @@ import * as React from "react";
 
 import { theme, styled } from "@washingtonpost/wpds-theme";
 
-import Check from "@washingtonpost/wpds-assets/asset/check";
-import Indeterminate from "@washingtonpost/wpds-assets/asset/indeterminate";
+import { Check, Indeterminate } from "@washingtonpost/wpds-assets";
 
 import * as PrimitiveCheckbox from "@radix-ui/react-checkbox";
 

--- a/ui/input-password/src/InputPassword.tsx
+++ b/ui/input-password/src/InputPassword.tsx
@@ -1,8 +1,7 @@
 import * as React from "react";
 import { InputText } from "@washingtonpost/wpds-input-text";
 import { Icon } from "@washingtonpost/wpds-icon";
-import Hide from "@washingtonpost/wpds-assets/asset/hide";
-import Show from "@washingtonpost/wpds-assets/asset/show";
+import { Hide, Show } from "@washingtonpost/wpds-assets";
 
 import type { InputTextProps } from "@washingtonpost/wpds-input-text";
 

--- a/ui/input-text/src/InputText.tsx
+++ b/ui/input-text/src/InputText.tsx
@@ -13,10 +13,7 @@ import { InputLabel } from "@washingtonpost/wpds-input-label";
 import { ErrorMessage } from "@washingtonpost/wpds-error-message";
 import { HelperText } from "@washingtonpost/wpds-helper-text";
 import { VisuallyHidden } from "@washingtonpost/wpds-visually-hidden";
-import Search from "@washingtonpost/wpds-assets/asset/search";
-import Globe from "@washingtonpost/wpds-assets/asset/globe";
-import Phone from "@washingtonpost/wpds-assets/asset/phone";
-import Email from "@washingtonpost/wpds-assets/asset/email";
+import { Search, Globe, Phone, Email } from "@washingtonpost/wpds-assets";
 
 const NAME = "InputText";
 


### PR DESCRIPTION
This PR changes Icon imports to use named imports allowing for compilation from esm.

Verified to work using Rollup, and Next. This style is properly tree shaken and does not increase package size in Next.

Before:
<img width="379" alt="image" src="https://user-images.githubusercontent.com/102534985/170076954-86e8e9e9-c168-4125-b082-671de6053745.png">

After:
<img width="347" alt="image" src="https://user-images.githubusercontent.com/102534985/170077070-a4178c1e-c54a-47b8-a7b6-d6894511423a.png">
 
