### PR TITLE
fix: allow for multiline labels in RadioButtons

### DIFF
--- a/ui/radio-group/src/RadioButton.tsx
+++ b/ui/radio-group/src/RadioButton.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
-//import type { RadioGroupItemProps } from "@radix-ui/react-radio-group";
 import * as Theme from "@washingtonpost/wpds-theme";
 import type * as WPDS from "@washingtonpost/wpds-theme";
 import { InputLabel } from "@washingtonpost/wpds-input-label";
@@ -8,7 +7,7 @@ import { InputLabel } from "@washingtonpost/wpds-input-label";
 const NAME = "RadioButton";
 
 const ContainerCSS = Theme.css({
-  alignItems: "center",
+  alignItems: "flex-start",
   display: "flex",
 });
 
@@ -19,8 +18,9 @@ const StyledRadioButton = Theme.styled(RadioGroupPrimitive.Item, {
   borderRadius: "50%",
   borderWidth: "1px",
   cursor: "pointer",
-  width: 20,
-  height: 20,
+  width: Theme.theme.sizes["125"],
+  minWidth: Theme.theme.sizes["125"],
+  height: Theme.theme.sizes["125"],
   "&:focus": { borderColor: Theme.theme.colors.cta },
   "&:disabled": {
     backgroundColor: Theme.theme.colors.disabled,
@@ -61,6 +61,17 @@ const StyledRadioButton = Theme.styled(RadioGroupPrimitive.Item, {
       },
     },
   },
+  compoundVariants: [
+    {
+      variant: "secondary",
+      isOutline: true,
+      css: {
+        "&[aria-checked='true']:enabled": {
+          backgroundColor: "transparent",
+        },
+      },
+    },
+  ],
 });
 
 const StyledRadioIndicator = Theme.styled(RadioGroupPrimitive.Indicator, {
@@ -73,8 +84,8 @@ const StyledRadioIndicator = Theme.styled(RadioGroupPrimitive.Indicator, {
   "&::after": {
     content: '""',
     display: "block",
-    width: 10,
-    height: 10,
+    width: "0.625rem",
+    height: "0.625rem",
     borderRadius: "50%",
     backgroundColor: Theme.theme.colors.primary,
   },
@@ -107,8 +118,9 @@ const StyledRadioIndicator = Theme.styled(RadioGroupPrimitive.Indicator, {
 });
 
 const labelCSS = {
-  paddingInlineStart: Theme.theme.space["050"],
   cursor: "pointer",
+  paddingBlockStart: "0.125rem",
+  paddingInlineStart: Theme.theme.space["050"],
 };
 
 interface RadioButtonProps

--- a/ui/radio-group/src/play.stories.jsx
+++ b/ui/radio-group/src/play.stories.jsx
@@ -36,20 +36,21 @@ RadioGroup.parameters = {
   chromatic: { disableSnapshot: true },
 };
 
-const Column = styled("div", {
-  display: "flex",
-  flexDirection: "column",
-  gap: "$100",
-  alignItems: "center",
-  marginBlockStart: "$200",
-});
+const OverflowTemplate = () => (
+  <Component legend="RadioGroup" name="test" css={{ maxWidth: "170px" }}>
+    <RadioButton
+      label="Option 1 demonstrates how this text wraps to multiple lines"
+      value="opt1"
+      id="opt1"
+    />
+    <RadioButton label="Option 2" value="opt2" id="opt2" />
+  </Component>
+);
 
-const HStack = styled("section", {
-  display: "flex",
-  flexDirection: "row",
-  gap: "$100",
-  borderRadius: "$075",
-});
+export const Overflow = OverflowTemplate.bind({});
+Overflow.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 const ControlledTemplate = () => {
   const [value, setValue] = React.useState("opt1");
@@ -74,6 +75,21 @@ export const Controlled = ControlledTemplate.bind({});
 Controlled.parameters = {
   chromatic: { disableSnapshot: true },
 };
+
+const Column = styled("div", {
+  display: "flex",
+  flexDirection: "column",
+  gap: "$100",
+  alignItems: "center",
+  marginBlockStart: "$200",
+});
+
+const HStack = styled("section", {
+  display: "flex",
+  flexDirection: "row",
+  gap: "$100",
+  borderRadius: "$075",
+});
 
 const ChromaticTemplate = () => (
   <Column>
@@ -132,6 +148,19 @@ const ChromaticTemplate = () => (
     >
       <RadioButton label="Option 1" value="opt1" id="e-opt1" checked />
       <RadioButton label="Option 2" value="opt2" id="e-opt2" />
+    </Component>
+    <h3>Overflow</h3>
+    <Component
+      legend="Select an option"
+      name="overflow"
+      css={{ maxWidth: "170px" }}
+    >
+      <RadioButton
+        label="Option 1 demonstrates how this text wraps to multiple lines"
+        value="opt1"
+        id="o-opt1"
+      />
+      <RadioButton label="Option 2" value="opt2" id="o-opt2" />
     </Component>
   </Column>
 );


### PR DESCRIPTION
The PR updates RadioButton's layout to allow for multiline labels

<img width="183" alt="image" src="https://user-images.githubusercontent.com/102534985/170789933-ba50e00b-e690-4223-870c-ac14cfe65fd5.png">



