### PR TITLE
fix!: remove global transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,12 @@ npm i @washingtonpost/wpds-ui-kit
 - Feel free to reach out to [#wpds on Slack](https://washpost.slack.com/archives/C01FWHF12BG) if you have any questions or run into any problems.
 - [Explore the Docs Site](https://build.washingtonpost.com) for usage examples and additional documentation on each component. You can also find additional resources under the [resources](https://build.washingtonpost.com/resources), [guides](https://build.washingtonpost.com/resources/guides), and [support](https://build.washingtonpost.com/support) pages.
 - There is also a storybook site that is used for component development only. If you're looking for code examples or information on how to use a specific component, please refer to build.washingtonpost.com.
+
+### Upgrading
+
+- Previous v0.12 `globalStyles` contained a globally applied transition to all CSS properties on all elements. After upgrading any component element that relied on that transition will need to apply one locally using wpds theme variables.
+  ```javascript
+  transition: theme.transitions.allFast,
+  // or
+  transition: `background ${theme.transitions.fast} ${theme.transitions.inOut`
+  ```

--- a/ui/button/src/Button.tsx
+++ b/ui/button/src/Button.tsx
@@ -17,6 +17,7 @@ export const Button = styled("button", {
   fontSize: "$100",
   lineHeight: "$100",
   gap: "$050",
+  transition: `background ${theme.transitions.fast} ${theme.transitions.inOut}`,
 
   "&:disabled": {
     color: "$onDisabled",

--- a/ui/checkbox/src/Checkbox.tsx
+++ b/ui/checkbox/src/Checkbox.tsx
@@ -9,7 +9,7 @@ import * as PrimitiveCheckbox from "@radix-ui/react-checkbox";
 import { InputLabel } from "@washingtonpost/wpds-input-label";
 
 const StyledCheckbox = styled(PrimitiveCheckbox.Root, {
-  transition: "$allFast",
+  transition: `background ${theme.transitions.fast} ${theme.transitions.inOut}`,
   appearance: "none",
   borderRadius: "$012",
   border: "1px solid",

--- a/ui/input-text/src/InputText.tsx
+++ b/ui/input-text/src/InputText.tsx
@@ -85,6 +85,7 @@ const TextInputLabel = styled(InputLabel, {
   position: "absolute",
   pointerEvents: "none",
   transform: `translateY(${theme.space["100"]})`,
+  transition: theme.transitions.allFast,
   variants: {
     isFloating: {
       true: {

--- a/ui/input-textarea/src/InputTextarea.tsx
+++ b/ui/input-textarea/src/InputTextarea.tsx
@@ -38,6 +38,7 @@ const TextAreaLabel = Theme.styled(InputLabel, {
   insetInlineStart: "$050",
   pointerEvents: "none",
   position: "absolute",
+  transition: Theme.theme.transitions.allFast,
   variants: {
     isFloating: {
       true: {

--- a/ui/radio-group/src/RadioButton.tsx
+++ b/ui/radio-group/src/RadioButton.tsx
@@ -18,10 +18,12 @@ const StyledRadioButton = Theme.styled(RadioGroupPrimitive.Item, {
   borderRadius: "50%",
   borderWidth: "1px",
   cursor: "pointer",
+  transition: Theme.theme.transitions.allFast,
   width: Theme.theme.sizes["125"],
   minWidth: Theme.theme.sizes["125"],
   height: Theme.theme.sizes["125"],
   "&:focus": { borderColor: Theme.theme.colors.cta },
+  "&:focus-visible": { outline: "none" },
   "&:disabled": {
     backgroundColor: Theme.theme.colors.disabled,
     borderColor: Theme.theme.colors.onDisabled,

--- a/ui/theme/src/stitches.config.ts
+++ b/ui/theme/src/stitches.config.ts
@@ -109,7 +109,6 @@ export const globalStyles = globalCss({
     margin: 0,
     padding: 0,
     boxSizing: "border-box",
-    transition: "$allFast",
   },
   html: {
     overflowX: "hidden",


### PR DESCRIPTION
BREAKING CHANGE: any element relying on global transition being present will no longer have a transition

## What I did

This PR removes the global css transition and replaces it where necessary in individual components
