### PR TITLE
feat: upgrade to stitches 1.2.8

### DIFF
--- a/build.washingtonpost.com/package.json
+++ b/build.washingtonpost.com/package.json
@@ -19,7 +19,7 @@
     "@radix-ui/react-checkbox": "^0.1.5",
     "@radix-ui/react-collapsible": "^0.1.6",
     "@react-aria/ssr": "^3.1.0",
-    "@stitches/react": "^1.2.7",
+    "@stitches/react": "^1.2.8",
     "@washingtonpost/site-components": "latest",
     "@washingtonpost/site-footer": "latest",
     "@washingtonpost/site-third-party-scripts": "latest",
@@ -42,7 +42,7 @@
     "react-toastify": "^8.2.0",
     "remark-gfm": "^3.0.1",
     "remark-mdx-code-meta": "^1.0.0",
-    "typescript": "^4.5.4"
+    "typescript": "^4.7.4"
   },
   "overrides": {
     "@washingtonpost/wpds-assets": "1.8.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       "dependencies": {
         "@radix-ui/react-avatar": "latest",
         "@radix-ui/react-checkbox": "latest",
-        "@stitches/react": "^1.2.6",
+        "@stitches/react": "^1.2.8",
         "@washingtonpost/wpds-alert-banner": "*",
         "@washingtonpost/wpds-app-bar": "*",
         "@washingtonpost/wpds-assets": "^1.8.1",
@@ -102,7 +102,7 @@
         "storybook-dark-mode": "^1.0.9",
         "tsup": "^5.12.5",
         "turbo": "^1.2.16",
-        "typescript": "4.5.5"
+        "typescript": "^4.7.4"
       },
       "optionalDependencies": {
         "esbuild-android-64": "0.14.25",
@@ -158,7 +158,7 @@
         "@radix-ui/react-checkbox": "^0.1.5",
         "@radix-ui/react-collapsible": "^0.1.6",
         "@react-aria/ssr": "^3.1.0",
-        "@stitches/react": "^1.2.7",
+        "@stitches/react": "^1.2.8",
         "@washingtonpost/site-components": "latest",
         "@washingtonpost/site-footer": "latest",
         "@washingtonpost/site-third-party-scripts": "latest",
@@ -181,7 +181,7 @@
         "react-toastify": "^8.2.0",
         "remark-gfm": "^3.0.1",
         "remark-mdx-code-meta": "^1.0.0",
-        "typescript": "^4.5.4"
+        "typescript": "^4.7.4"
       },
       "devDependencies": {
         "@next/bundle-analyzer": "^12.1.0",
@@ -12142,8 +12142,9 @@
       "integrity": "sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg=="
     },
     "node_modules/@stitches/react": {
-      "version": "1.2.7",
-      "license": "MIT",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@stitches/react/-/react-1.2.8.tgz",
+      "integrity": "sha512-9g9dWI4gsSVe8bNLlb+lMkBYsnIKCZTmvqvDG+Avnn69XfmHZKiaMrx7cgTaddq7aTPPmXiTsbFcUy0xgI4+wA==",
       "peerDependencies": {
         "react": ">= 16.3.0"
       }
@@ -46592,8 +46593,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.5",
-      "license": "Apache-2.0",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -48649,6 +48651,19 @@
         "react": "^16.8.6 || ^17.0.2"
       }
     },
+    "ui/alert-banner/node_modules/typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "ui/app-bar": {
       "name": "@washingtonpost/wpds-app-bar",
       "version": "0.11.1",
@@ -48664,6 +48679,19 @@
       "peerDependencies": {
         "@washingtonpost/wpds-theme": "*",
         "react": "^16.8.6 || ^17.0.2"
+      }
+    },
+    "ui/app-bar/node_modules/typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "ui/avatar": {
@@ -48684,6 +48712,19 @@
         "react": "^16.8.6 || ^17.0.2"
       }
     },
+    "ui/avatar/node_modules/typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "ui/box": {
       "name": "@washingtonpost/wpds-box",
       "version": "0.11.1",
@@ -48699,6 +48740,19 @@
       "peerDependencies": {
         "@washingtonpost/wpds-theme": "*",
         "react": "^16.8.6 || ^17.0.2"
+      }
+    },
+    "ui/box/node_modules/typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "ui/build.washingtonpost.com": {
@@ -49114,6 +49168,19 @@
         "react": "^16.8.6 || ^17.0.2"
       }
     },
+    "ui/button/node_modules/typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "ui/checkbox": {
       "name": "@washingtonpost/wpds-checkbox",
       "version": "0.11.2",
@@ -49139,6 +49206,19 @@
         "react": "^16.8.6 || ^17.0.2"
       }
     },
+    "ui/checkbox/node_modules/typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "ui/container": {
       "name": "@washingtonpost/wpds-container",
       "version": "0.11.1",
@@ -49154,6 +49234,19 @@
       "peerDependencies": {
         "@washingtonpost/wpds-theme": "*",
         "react": "^16.8.6 || ^17.0.2"
+      }
+    },
+    "ui/container/node_modules/typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "ui/divider": {
@@ -49173,6 +49266,19 @@
         "react": "^16.8.6 || ^17.0.2"
       }
     },
+    "ui/divider/node_modules/typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "ui/error-message": {
       "name": "@washingtonpost/wpds-error-message",
       "version": "0.11.1",
@@ -49187,6 +49293,19 @@
       "peerDependencies": {
         "@washingtonpost/wpds-theme": "*",
         "react": "^16.8.6 || ^17.0.2"
+      }
+    },
+    "ui/error-message/node_modules/typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "ui/eslint-plugin": {
@@ -50206,6 +50325,19 @@
         "react": "^16.8.6 || ^17.0.2"
       }
     },
+    "ui/fieldset/node_modules/typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "ui/helper-text": {
       "name": "@washingtonpost/wpds-helper-text",
       "version": "0.11.1",
@@ -50220,6 +50352,19 @@
       "peerDependencies": {
         "@washingtonpost/wpds-theme": "*",
         "react": "^16.8.6 || ^17.0.2"
+      }
+    },
+    "ui/helper-text/node_modules/typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "ui/icon": {
@@ -50241,6 +50386,19 @@
         "react": "^16.8.6 || ^17.0.2"
       }
     },
+    "ui/icon/node_modules/typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "ui/input-label": {
       "name": "@washingtonpost/wpds-input-label",
       "version": "0.11.1",
@@ -50256,6 +50414,19 @@
       "peerDependencies": {
         "@washingtonpost/wpds-theme": "*",
         "react": "^16.8.6 || ^17.0.2"
+      }
+    },
+    "ui/input-label/node_modules/typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "ui/input-password": {
@@ -50278,6 +50449,19 @@
         "react": "^16.8.6 || ^17.0.2"
       }
     },
+    "ui/input-password/node_modules/typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "ui/input-shared": {
       "name": "@washingtonpost/wpds-input-shared",
       "version": "0.11.1",
@@ -50292,6 +50476,19 @@
       "peerDependencies": {
         "@washingtonpost/wpds-theme": "*",
         "react": "^16.8.6 || ^17.0.2"
+      }
+    },
+    "ui/input-shared/node_modules/typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "ui/input-text": {
@@ -50340,6 +50537,19 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "ui/input-text/node_modules/typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "ui/input-textarea": {
       "name": "@washingtonpost/wpds-input-textarea",
       "version": "0.11.1",
@@ -50363,6 +50573,19 @@
         "@washingtonpost/wpds-input-shared": "*",
         "@washingtonpost/wpds-theme": "*",
         "react": "^16.8.6 || ^17.0.2"
+      }
+    },
+    "ui/input-textarea/node_modules/typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "ui/kit": {
@@ -50420,6 +50643,19 @@
         "@washingtonpost/wpds-visually-hidden": "*"
       }
     },
+    "ui/kit/node_modules/typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "ui/radio-group": {
       "name": "@washingtonpost/wpds-radio-group",
       "version": "0.11.1",
@@ -50444,6 +50680,19 @@
         "react": "^16.8.6 || ^17.0.2"
       }
     },
+    "ui/radio-group/node_modules/typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "ui/theme": {
       "name": "@washingtonpost/wpds-theme",
       "version": "0.11.1",
@@ -50457,6 +50706,19 @@
       },
       "peerDependencies": {
         "@stitches/react": "*"
+      }
+    },
+    "ui/theme/node_modules/typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "ui/visually-hidden": {
@@ -50474,6 +50736,19 @@
       "peerDependencies": {
         "@washingtonpost/wpds-theme": "*",
         "react": "^16.8.6 || ^17.0.2"
+      }
+    },
+    "ui/visually-hidden/node_modules/typescript": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     }
   },
@@ -58526,7 +58801,9 @@
       "integrity": "sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg=="
     },
     "@stitches/react": {
-      "version": "1.2.7",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@stitches/react/-/react-1.2.8.tgz",
+      "integrity": "sha512-9g9dWI4gsSVe8bNLlb+lMkBYsnIKCZTmvqvDG+Avnn69XfmHZKiaMrx7cgTaddq7aTPPmXiTsbFcUy0xgI4+wA==",
       "requires": {}
     },
     "@storybook/addon-a11y": {
@@ -65043,6 +65320,14 @@
         "react": "^16.8.6 || ^17.0.2",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+          "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+          "dev": true
+        }
       }
     },
     "@washingtonpost/wpds-app-bar": {
@@ -65052,6 +65337,14 @@
         "react": "^16.8.6 || ^17.0.2",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+          "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+          "dev": true
+        }
       }
     },
     "@washingtonpost/wpds-assets": {
@@ -65070,6 +65363,14 @@
         "@washingtonpost/wpds-theme": "0.11.1",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+          "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+          "dev": true
+        }
       }
     },
     "@washingtonpost/wpds-box": {
@@ -65079,6 +65380,14 @@
         "react": "^16.8.6 || ^17.0.2",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+          "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+          "dev": true
+        }
       }
     },
     "@washingtonpost/wpds-button": {
@@ -65088,6 +65397,14 @@
         "react": "^16.8.6 || ^17.0.2",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+          "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+          "dev": true
+        }
       }
     },
     "@washingtonpost/wpds-checkbox": {
@@ -65101,6 +65418,14 @@
         "react": "^16.8.6 || ^17.0.2",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+          "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+          "dev": true
+        }
       }
     },
     "@washingtonpost/wpds-container": {
@@ -65110,6 +65435,14 @@
         "react": "^16.8.6 || ^17.0.2",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+          "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+          "dev": true
+        }
       }
     },
     "@washingtonpost/wpds-divider": {
@@ -65119,6 +65452,14 @@
         "@washingtonpost/wpds-theme": "0.11.1",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+          "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+          "dev": true
+        }
       }
     },
     "@washingtonpost/wpds-docs": {
@@ -65133,7 +65474,7 @@
         "@radix-ui/react-checkbox": "^0.1.5",
         "@radix-ui/react-collapsible": "^0.1.6",
         "@react-aria/ssr": "^3.1.0",
-        "@stitches/react": "^1.2.7",
+        "@stitches/react": "^1.2.8",
         "@types/lz-string": "^1.3.34",
         "@types/node": "^17.0.21",
         "@types/react": "^17.0.38",
@@ -65168,7 +65509,7 @@
         "react-toastify": "^8.2.0",
         "remark-gfm": "^3.0.1",
         "remark-mdx-code-meta": "^1.0.0",
-        "typescript": "^4.5.4"
+        "typescript": "^4.7.4"
       },
       "dependencies": {
         "@codesandbox/sandpack-client": {
@@ -65373,6 +65714,14 @@
         "@washingtonpost/wpds-theme": "0.11.1",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+          "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+          "dev": true
+        }
       }
     },
     "@washingtonpost/wpds-fieldset": {
@@ -65381,6 +65730,14 @@
         "@washingtonpost/wpds-theme": "0.11.1",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+          "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+          "dev": true
+        }
       }
     },
     "@washingtonpost/wpds-helper-text": {
@@ -65389,6 +65746,14 @@
         "@washingtonpost/wpds-theme": "0.11.1",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+          "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+          "dev": true
+        }
       }
     },
     "@washingtonpost/wpds-icon": {
@@ -65399,6 +65764,14 @@
         "react": "^16.8.6 || ^17.0.2",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+          "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+          "dev": true
+        }
       }
     },
     "@washingtonpost/wpds-input-label": {
@@ -65408,6 +65781,14 @@
         "@washingtonpost/wpds-theme": "0.11.1",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+          "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+          "dev": true
+        }
       }
     },
     "@washingtonpost/wpds-input-password": {
@@ -65418,6 +65799,14 @@
         "@washingtonpost/wpds-input-text": "0.11.2",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+          "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+          "dev": true
+        }
       }
     },
     "@washingtonpost/wpds-input-shared": {
@@ -65426,6 +65815,14 @@
         "@washingtonpost/wpds-theme": "0.11.1",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+          "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+          "dev": true
+        }
       }
     },
     "@washingtonpost/wpds-input-text": {
@@ -65449,6 +65846,12 @@
       "dependencies": {
         "nanoid": {
           "version": "3.3.2"
+        },
+        "typescript": {
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+          "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+          "dev": true
         }
       }
     },
@@ -65463,6 +65866,14 @@
         "react": "^16.8.6 || ^17.0.2",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+          "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+          "dev": true
+        }
       }
     },
     "@washingtonpost/wpds-radio-group": {
@@ -65476,6 +65887,14 @@
         "nanoid": "^3.3.3",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+          "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+          "dev": true
+        }
       }
     },
     "@washingtonpost/wpds-theme": {
@@ -65484,6 +65903,14 @@
         "@stitches/react": "*",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+          "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+          "dev": true
+        }
       }
     },
     "@washingtonpost/wpds-ui-kit": {
@@ -65512,6 +65939,14 @@
         "@washingtonpost/wpds-visually-hidden": "0.11.2",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+          "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+          "dev": true
+        }
       }
     },
     "@washingtonpost/wpds-visually-hidden": {
@@ -65521,6 +65956,14 @@
         "react": "^16.8.6 || ^17.0.2",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+          "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+          "dev": true
+        }
       }
     },
     "@webassemblyjs/ast": {
@@ -82956,7 +83399,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.5"
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
     },
     "uglify-js": {
       "version": "3.15.2",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "storybook-dark-mode": "^1.0.9",
     "tsup": "^5.12.5",
     "turbo": "^1.2.16",
-    "typescript": "4.5.5",
+    "typescript": "^4.7.4",
     "@types/lz-string": "^1.3.34",
     "@types/node": "^17.0.21",
     "babel-plugin-extract-react-types": "^0.1.14",
@@ -95,7 +95,7 @@
   "dependencies": {
     "@radix-ui/react-avatar": "latest",
     "@radix-ui/react-checkbox": "latest",
-    "@stitches/react": "^1.2.6",
+    "@stitches/react": "^1.2.8",
     "@washingtonpost/wpds-alert-banner": "*",
     "@washingtonpost/wpds-app-bar": "*",
     "@washingtonpost/wpds-avatar": "*",
@@ -184,8 +184,7 @@
     }
   },
   "overrides": {
-    "react-docgen-typescript": "^2.2.2",
-    "typescript": "4.5.5"
+    "react-docgen-typescript": "^2.2.2"
   },
   "packageManager": "npm@8.11.0"
 }

--- a/ui/theme/src/stitches.config.ts
+++ b/ui/theme/src/stitches.config.ts
@@ -1,11 +1,11 @@
-import * as stitches from "@stitches/react";
-import type * as Stitches from "@stitches/react";
+import { createStitches, type CSS as stitchesCss } from "@stitches/react";
+import type { PropertyValue } from "@stitches/react";
 import * as tokens from "./tokens";
 export type { VariantProps } from "@stitches/react";
 
 const prefix = "wpds";
 
-const WPDS = stitches.createStitches({
+const WPDS = createStitches({
   prefix,
   theme: {
     colors: {
@@ -54,30 +54,30 @@ const WPDS = stitches.createStitches({
     light: "(prefers-color-scheme: light)",
   },
   utils: {
-    px: (value: Stitches.PropertyValue<"padding">) => ({
+    px: (value: PropertyValue<"padding">) => ({
       paddingLeft: value,
       paddingRight: value,
     }),
-    py: (value: Stitches.PropertyValue<"padding">) => ({
+    py: (value: PropertyValue<"padding">) => ({
       paddingTop: value,
       paddingBottom: value,
     }),
-    my: (value: Stitches.PropertyValue<"margin">) => ({
+    my: (value: PropertyValue<"margin">) => ({
       marginTop: value,
       marginBottom: value,
     }),
-    mx: (value: Stitches.PropertyValue<"margin">) => ({
+    mx: (value: PropertyValue<"margin">) => ({
       marginLeft: value,
       marginRight: value,
     }),
-    size: (value: Stitches.PropertyValue<"width" | "height">) => ({
+    size: (value: PropertyValue<"width" | "height">) => ({
       width: value,
       height: value,
     }),
   },
 });
 
-export type CSS = stitches.CSS<typeof WPDS>;
+export type CSS = stitchesCss<typeof WPDS>;
 export const {
   styled,
   css,


### PR DESCRIPTION
## What I did

We are using wpds-ui-kit in our rewrite of the elections render engine, but there are some TypeScript incompatibilities with Stitches 1.2.6 (what's currently installed in wpds-ui-kit) and 1.2.8 (the latest version). To get wpds-ui-kit to play nice with our repo, we need to upgrade wpds-ui-kit to 1.2.8.

This PR bumps the version of Stitches as well as TypeScript (since as far as I can tell, the TypeScript version was lower because of TS bugs in Stitches 1.2.6). It requires minor code changes in wpds-theme to reexport stitches-related imports without `*` catch-alls. I'm not sure why that was needed, but there were TypeScript errors before about exporting variables using names from external modules that can't be named ([relevant StackOverflow](https://stackoverflow.com/questions/43900035/ts4023-exported-variable-x-has-or-is-using-name-y-from-external-module-but)).

I validated the build succeeds now, but additional testing should be made on the components to ensure there were no visual regressions.