### PR TITLE
fix(docs): EditInGithub alignment bug

### DIFF
--- a/build.washingtonpost.com/components/Footer.js
+++ b/build.washingtonpost.com/components/Footer.js
@@ -122,7 +122,6 @@ export const Footer = () => {
           )}.mdx`}
           target="_blank"
           rel="noopener noreferrer"
-          className="site-footer"
         >
           Edit this page on GitHub.
         </EditInGithub>

--- a/build.washingtonpost.com/components/Footer.js
+++ b/build.washingtonpost.com/components/Footer.js
@@ -74,7 +74,7 @@ const StyledFooter = styled(SiteFooter, {
 });
 
 const EditInGithub = styled("a", {
-  display: "inline-block",
+  display: "flex",
   textDecoration: "none",
   color: "$colors$onSecondary",
   fontSize: "$087",
@@ -100,6 +100,10 @@ export const Footer = () => {
         paddingTop: "$050",
         marginBottom: "$100",
         marginTop: "$500",
+        marginLeft: "auto",
+        marginRight: "auto",
+        maxWidth: "1028px",
+        width: "100%",
 
         "@sm": {
           marginTop: "$200",
@@ -118,6 +122,7 @@ export const Footer = () => {
           )}.mdx`}
           target="_blank"
           rel="noopener noreferrer"
+          className="site-footer"
         >
           Edit this page on GitHub.
         </EditInGithub>


### PR DESCRIPTION
## What I did

quick fix with the misalignment of the 'Edit this page on Github' link when the window is wide. Here is the original:
<img width="729" alt="Screen Shot 2022-07-27 at 3 13 59 PM" src="https://user-images.githubusercontent.com/67281745/182624649-6faabc2b-bbdb-4b42-85ab-521f47fc9735.png">

and here is the fix:
<img width="1280" alt="Screen Shot 2022-08-03 at 9 39 39 AM" src="https://user-images.githubusercontent.com/67281745/182624725-dc79c5cb-d1ae-4d22-8e93-58ef1bc5fb1a.png">