### PR TITLE
docs: remove typescript note

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -67,22 +67,9 @@ npm run new-component NewComponentName
 
 You can create an experimental release for testing by following the [release doc](https://github.com/washingtonpost/wpds-ui-kit/blob/main/docs/RELEASING.md)
 
-[## Contribute a component](https://build.washingtonpost.com/resources/guides/contribute-a-component)
+## Contribute a component
 
-[## Release a component](https://github.com/washingtonpost/wpds-ui-kit/blob/main/docs/RELEASING.md)
+- https://build.washingtonpost.com/resources/guides/contribute-a-component
 
-## Typescript
-
-### FAQ
-
-### Why is Typescript throwing warnings about the `css` object in Stitches?
-
-VS Code is using a newer version (`4.6.X`) of Typescript that is currently incompatible with Stitches ([They are using 4.4.3](https://github.com/modulz/stitches/blob/0ebaf9f988871ac0d8d5f2b72f2a8042e0d1b56f/package.json#L53)). We are using `4.5.5`.
-
-We recommend adding this setting to your `.vscode/settings.json` file:
-
-```json
-"typescript.tsdk": "./node_modules/typescript/lib"
-```
-
-Also pick the TS version in the language server settings. It will appear when a TS file is opened.
+## Release a component
+- https://github.com/washingtonpost/wpds-ui-kit/blob/main/docs/RELEASING.md


### PR DESCRIPTION
## What I did

we support typescript versions higher than 4.5.5 now.

<!--
  Explain the **motivation** for making this change. What existing problem does the pull request solve? Please be as detailed as possible.
-->
