### PR TITLE
Fix(workflows): failing integration test fix

### DIFF
--- a/.github/workflows/interaction-tests.yml
+++ b/.github/workflows/interaction-tests.yml
@@ -4,7 +4,7 @@ on: deployment_status
 
 jobs:
   tests:
-    if: github.event.deployment_status.state == 'success' && contains(github.event.deployment_status.target_url, "storybook")
+    if: github.event.deployment_status.state == 'success' && contains(github.event.deployment_status.target_url, 'storybook')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/interaction-tests.yml
+++ b/.github/workflows/interaction-tests.yml
@@ -4,7 +4,7 @@ on: deployment_status
 
 jobs:
   tests:
-    if: github.event.deployment_status.state == 'success'
+    if: github.event.deployment_status.state == 'success' && contains(github.event.deployment_status.target_url, "storybook")
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## What I did

Interaction tests in Github workflows were failing on deployment because storybook testing was being run on the docs site preview alongside the storybook preview. Just added a condition to only allow this test to run on storybook previews.

Tested this workflow in the dummy repo [Site-Engineering-Workflows-Testing-Ground](https://github.com/WPMedia/site-engineering-workflows-testing-ground).

<img width="968" alt="Screen Shot 2022-08-23 at 11 13 43 AM" src="https://user-images.githubusercontent.com/67281745/187465892-9801f51b-1cf5-4177-a61a-6a3624d71d1d.png">
