### PR TITLE
fix: change label to title as svg does not accept a title and ts will error

### DIFF
--- a/build.washingtonpost.com/docs/foundations/wam.mdx
+++ b/build.washingtonpost.com/docs/foundations/wam.mdx
@@ -108,7 +108,7 @@ have guidance around their use.
 
 ```jsx withPreview
 export default function Example() {
-  return <WashingtonPost width="250" label="The Washington Post logo" />;
+  return <WashingtonPost width="250" title="The Washington Post logo" />;
 }
 ```
 


### PR DESCRIPTION
## What I did

Typescript doesn't like label as it is not available on an svg. Rather title should be used: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/title. With title added, screenreaders will read the title.

![Screen Shot 2022-10-05 at 9 16 25 AM](https://user-images.githubusercontent.com/5349341/194069563-7e906b74-23dc-4edb-9936-f2c5dd1b35f6.png)

![Screen Shot 2022-10-05 at 9 17 50 AM](https://user-images.githubusercontent.com/5349341/194069872-018ae548-1dec-4f5b-ad6d-d22c6d5255e4.png)

