### PR TITLE
fix: move padding css out of transition element to avoid jumpy transition

### DIFF
--- a/ui/accordion/src/AccordionContent.tsx
+++ b/ui/accordion/src/AccordionContent.tsx
@@ -16,12 +16,8 @@ const slideUp = keyframes({
 
 const easeInOutExpo = `cubic-bezier(0.87, 0, 0.13, 1)`;
 
-const StyledContent = styled(AccordionPrimitive.Content, {
+const AnimatedContent = styled(AccordionPrimitive.Content, {
   overflow: "hidden",
-  color: theme.colors.primary,
-  paddingBottom: theme.space[150],
-  paddingRight: theme.space[150],
-
   '&[data-state="open"]': {
     animation: `${slideDown} ${theme.transitions.normal} ${easeInOutExpo}`,
   },
@@ -30,7 +26,13 @@ const StyledContent = styled(AccordionPrimitive.Content, {
   },
 });
 
-type AccordionContentVariants = WPDS.VariantProps<typeof StyledContent>;
+const ContentContainer = styled("div", {
+  color: theme.colors.primary,
+  paddingBottom: theme.space[150],
+  paddingRight: theme.space[150],
+});
+
+type AccordionContentVariants = WPDS.VariantProps<typeof AnimatedContent>;
 type CombinedProps = RadixAccordionContentProps & AccordionContentVariants;
 
 export interface AccordionContentInterface extends CombinedProps {
@@ -41,9 +43,9 @@ export const AccordionContent = React.forwardRef<
   HTMLDivElement,
   AccordionContentInterface
 >(({ children, ...props }: AccordionContentInterface, ref) => (
-  <StyledContent {...props} ref={ref}>
-    {children}
-  </StyledContent>
+  <AnimatedContent {...props} ref={ref}>
+    <ContentContainer>{children}</ContentContainer>
+  </AnimatedContent>
 ));
 
 AccordionContent.displayName = "AccordionContent";


### PR DESCRIPTION
## What I did

In the Accordion component, when expanding and collapsing the AccordionContent, the transition is jumpy due to the padding in the container. This is a common issue with transitions and I believe there are a few ways to solve it but we are limited due to the usage of radix-ui/react-accordion. The best I can come up with is move the padding into a child container. This fixes the jumpy transition as you can see in the below before and after.


![Before_AdobeExpress](https://user-images.githubusercontent.com/5349341/195637636-72a74a18-252f-4e0a-aa5d-4cf1382eb110.gif)
