### PR TITLE
fix(ui kit): support wpds color tokens for icon 'fill' property

### DIFF
--- a/ui/icon/src/icon.tsx
+++ b/ui/icon/src/icon.tsx
@@ -5,6 +5,13 @@ import type * as WPDS from "@washingtonpost/wpds-theme";
 
 const NAME = "Icon";
 
+export type WPDSThemeColorObject = {
+  token: string;
+  value: string;
+  scale: string;
+  prefix: string;
+};
+
 interface IconInterface extends React.SVGProps<HTMLOrSVGElement> {
   /**
    * The name of the icon to display.
@@ -14,6 +21,7 @@ interface IconInterface extends React.SVGProps<HTMLOrSVGElement> {
   children?: React.ReactNode;
   className?: string;
   css?: WPDS.CSS;
+  fill?: string & WPDSThemeColorObject;
 }
 
 export const Icon = React.forwardRef<React.ReactSVGElement, IconInterface>(

--- a/ui/icon/src/play.stories.jsx
+++ b/ui/icon/src/play.stories.jsx
@@ -17,6 +17,7 @@ Default.storyName = "Icon";
 Default.args = {
   size: "200",
   label: "Find out more information.",
+  fill: theme.colors["primary"],
   children: <Info />,
 };
 


### PR DESCRIPTION
## What I did

[Jira ticket](https://arcpublishing.atlassian.net/browse/WPDS-1228)
Fix based on bug report:
<img width="323" alt="Screen Shot 2022-10-16 at 3 31 08 PM" src="https://user-images.githubusercontent.com/67281745/196054343-aa8f5b83-2578-432b-b1b1-07ca38c9c99e.png">

Added support for using WPDS color tokens for Icon component's 'fill' property. Learned about TypeScript in the process. 

Tested in Storybook:
<img width="458" alt="Screen Shot 2022-10-16 at 3 35 16 PM" src="https://user-images.githubusercontent.com/67281745/196054517-6496cdc4-551f-4333-beff-c2f1c442af1b.png">
