### PR TITLE
fix: input textarea required

### DIFF
--- a/ui/input-textarea/src/InputTextarea.tsx
+++ b/ui/input-textarea/src/InputTextarea.tsx
@@ -144,6 +144,7 @@ export const InputTextarea = React.forwardRef<
             isInvalid: error,
             isDisabled: disabled,
           })}
+          required={required}
           disabled={disabled}
           onFocus={handleFocus}
           onBlur={handleBlur}


### PR DESCRIPTION
## What I did

The `input` element added to the DOM when using the `InputTextarea` component does not honor the `required` prop passed to the component. That is, it is missing the `required` attribute when the prop is set to `true`. This is problematic for form validation. This change should resolve the issue.