### PR TITLE
chore: refactor icon story to tsx

### DIFF
--- a/ui/icon/src/play.stories.tsx
+++ b/ui/icon/src/play.stories.tsx
@@ -1,14 +1,15 @@
 import * as React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { Box, theme } from "@washingtonpost/wpds-ui-kit";
 import Info from "@washingtonpost/wpds-assets/asset/info";
-import { Icon as Component } from "./icon";
+import { Icon } from "./icon";
 
 export default {
   title: "Icon",
-  component: Component,
-};
+  component: Icon,
+} as ComponentMeta<typeof Icon>;
 
-const Template = (args) => <Component {...args} />;
+const Template: ComponentStory<typeof Icon> = (args) => <Icon {...args} />;
 
 export const Default = Template.bind({});
 


### PR DESCRIPTION
## What I did

Icon component had a typescript bug in it which could have been surfaced in the storybook story if the story was written in typescript (see fill property in below screenshot. Changing the story to typescript to illustrate this and serve as a template moving forward. This branch will not run storybook and will fail test-storybook until the icon PR is merged: https://github.com/washingtonpost/wpds-ui-kit/pull/269

![Screen Shot 2022-11-22 at 10 33 36 AM](https://user-images.githubusercontent.com/5349341/203355220-8037c804-8323-442e-8a80-d40c472f97cd.png)


