### PR TITLE
feat: updated wam version and asset import copy text

### DIFF
--- a/build.washingtonpost.com/components/Markdown/Examples/IconSamples.jsx
+++ b/build.washingtonpost.com/components/Markdown/Examples/IconSamples.jsx
@@ -6,14 +6,7 @@ import MDXStyling from "~/components/Markdown/Styling";
 import { Grid } from "../Components/Grid";
 import { InputText } from "@washingtonpost/wpds-input-text";
 import Search from "@washingtonpost/wpds-assets/asset/search";
-import {
-  Icon,
-  theme,
-  Button,
-  AlertBanner,
-  Box,
-  styled,
-} from "@washingtonpost/wpds-ui-kit";
+import { Icon, theme, AlertBanner, Box } from "@washingtonpost/wpds-ui-kit";
 import { paramCase } from "param-case";
 import { pascalCase } from "pascal-case";
 import { logoList } from "./LogoSamples";
@@ -23,28 +16,28 @@ export default function Icons({ data }) {
     keys: ["name", "description"],
     threshold: 0.5,
   });
-  const SuccessToast = () => {
-    return (
-      <AlertBanner.Root variant="success">
-        <AlertBanner.Content css={{ minWidth: 250, paddingRight: "$050" }}>
-          <b>Copied: </b>
-          <Box as="span" css={{ fontSize: 16 }}>
-            Import statement for{" "}
-            <Box as="i" css={{ textTransform: "capitalize" }}>
-              {Name}
-            </Box>
-          </Box>
-        </AlertBanner.Content>
-      </AlertBanner.Root>
-    );
-  };
+
   const [ExampleToCopy, setExampleToCopy] = useState(null);
   const [Name, setName] = useState("");
-  const [inFocus, setInFocus] = useState(false);
   const [Filter, setFilter] = useState([]);
   useEffect(() => {
     if (ExampleToCopy) {
       window.navigator.clipboard.writeText(ExampleToCopy);
+      const SuccessToast = () => {
+        return (
+          <AlertBanner.Root variant="success">
+            <AlertBanner.Content css={{ minWidth: 250, paddingRight: "$050" }}>
+              <b>Copied: </b>
+              <Box as="span" css={{ fontSize: 16 }}>
+                Import statement for{" "}
+                <Box as="i" css={{ textTransform: "capitalize" }}>
+                  {Name}
+                </Box>
+              </Box>
+            </AlertBanner.Content>
+          </AlertBanner.Root>
+        );
+      };
       toast(<SuccessToast />, {
         position: "top-center",
         closeButton: false,
@@ -56,7 +49,7 @@ export default function Icons({ data }) {
         },
       });
     }
-  }, [ExampleToCopy]);
+  }, [ExampleToCopy, Name]);
 
   function setVariables(example, Name) {
     setName(Name);
@@ -88,13 +81,7 @@ export default function Icons({ data }) {
       }
       const componentName = paramCase(Asset);
 
-      const importExample = `import ${Asset.replace(
-        "Svg",
-        ""
-      )} from "@washingtonpost/wpds-assets/asset/${componentName.replace(
-        "svg",
-        ""
-      )}";`;
+      const importExample = `import { ${Asset} } from "@washingtonpost/wpds-assets";`;
 
       return (
         <MDXStyling.Cell key={i}>

--- a/build.washingtonpost.com/components/Markdown/Examples/LogoSamples.jsx
+++ b/build.washingtonpost.com/components/Markdown/Examples/LogoSamples.jsx
@@ -87,13 +87,7 @@ const Logos = () => {
       const Sample = AllAssets[Asset];
       const componentName = paramCase(Asset);
 
-      const importExample = `import ${Asset.replace(
-        "Svg",
-        ""
-      )} from "@washingtonpost/wpds-assets/asset/${componentName.replace(
-        "svg",
-        ""
-      )}";`;
+      const importExample = `import { ${Asset} } from "@washingtonpost/wpds-assets";`;
 
       if (!logoList.includes(componentName)) return;
       return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@washingtonpost/wpds-accordion": "*",
         "@washingtonpost/wpds-alert-banner": "*",
         "@washingtonpost/wpds-app-bar": "*",
-        "@washingtonpost/wpds-assets": "^1.13.0",
+        "@washingtonpost/wpds-assets": "^1.14.0",
         "@washingtonpost/wpds-avatar": "*",
         "@washingtonpost/wpds-box": "*",
         "@washingtonpost/wpds-button": "*",
@@ -22417,9 +22417,9 @@
       "link": true
     },
     "node_modules/@washingtonpost/wpds-assets": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-assets/-/wpds-assets-1.13.0.tgz",
-      "integrity": "sha512-Lc7/k6w+5j8+DqOP6jInCYzHcQS/QHwja3W/wCIzpUCLoWGjoXXl/JaR0NGnPKaI4LcxVNSHe9a7wMpmnzzBXQ==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-assets/-/wpds-assets-1.14.0.tgz",
+      "integrity": "sha512-s2sGsY3IunQOcJ2slSfBUfnMfdW7vfHSIkYAarLPpDAEbWPF3obOyh8+zawHRnBv5JRT6lqWB2wJnPHPt+enZA==",
       "dependencies": {
         "react": "^16.0.1 || ^17.0.2",
         "react-dom": "^16.0.1 || ^17.0.2"
@@ -70499,9 +70499,9 @@
       }
     },
     "@washingtonpost/wpds-assets": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-assets/-/wpds-assets-1.13.0.tgz",
-      "integrity": "sha512-Lc7/k6w+5j8+DqOP6jInCYzHcQS/QHwja3W/wCIzpUCLoWGjoXXl/JaR0NGnPKaI4LcxVNSHe9a7wMpmnzzBXQ==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-assets/-/wpds-assets-1.14.0.tgz",
+      "integrity": "sha512-s2sGsY3IunQOcJ2slSfBUfnMfdW7vfHSIkYAarLPpDAEbWPF3obOyh8+zawHRnBv5JRT6lqWB2wJnPHPt+enZA==",
       "requires": {
         "react": "^16.0.1 || ^17.0.2",
         "react-dom": "^16.0.1 || ^17.0.2"

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "@washingtonpost/wpds-accordion": "*",
     "@washingtonpost/wpds-alert-banner": "*",
     "@washingtonpost/wpds-app-bar": "*",
-    "@washingtonpost/wpds-assets": "^1.13.0",
+    "@washingtonpost/wpds-assets": "^1.14.0",
     "@washingtonpost/wpds-avatar": "*",
     "@washingtonpost/wpds-box": "*",
     "@washingtonpost/wpds-button": "*",


### PR DESCRIPTION
## What I did

This PR updates the WPDS Assets package and the import code that is copied to the clipboard for assets to favor importing from the top-level package.
