### PR TITLE
feat: allow for use of Select in example form on mobile

### DIFF
--- a/build.washingtonpost.com/components/Layout/Layout.js
+++ b/build.washingtonpost.com/components/Layout/Layout.js
@@ -21,7 +21,7 @@ const Grid = styled("div", {
     paddingRight: "$100",
   },
   "@sm": {
-    height: "100vh",
+    minHeight: "100vh",
     gridTemplateColumns: "1fr",
     gridTemplateRows: "auto auto 1fr",
     gridTemplateAreas: `

--- a/build.washingtonpost.com/pages/working-examples/index.tsx
+++ b/build.washingtonpost.com/pages/working-examples/index.tsx
@@ -300,8 +300,6 @@ const Form = () => {
                 }}
                 render={({ field }) => (
                   <Select.Root
-                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                    // @ts-ignore
                     value={field.value}
                     onValueChange={field.onChange}
                     error={!!errors.state}

--- a/ui/select/src/Select.tsx
+++ b/ui/select/src/Select.tsx
@@ -28,18 +28,6 @@ type SelectContextProps = {
 
 export const SelectContext = React.createContext({} as SelectContextProps);
 
-type Controlled = {
-  /** Controlled value for the current page */
-  value: number;
-  defaultValue?: never;
-};
-type Uncontrolled = {
-  value?: never;
-  /** Uncontrolled value for the initial page shown */
-  defaultValue?: number;
-};
-type ControlledOrUncontrolled = Controlled | Uncontrolled;
-
 type SelectRootVariants = WPDS.VariantProps<typeof SelectPrimitive.Root>;
 
 export type SelectRootProps = {
@@ -47,8 +35,6 @@ export type SelectRootProps = {
   children?: React.ReactNode;
   /** Overrides for the input text styles. Padding overrides affect the input container and  */
   css?: WPDS.CSS;
-  /** The value of the select when initially rendered. Use when you do not need to control the state of the select. */
-  defaultValue?: string;
   // /** Whether the content should be displayed from the beginning. */
   // defaultOpen?: boolean;
   /** The underlying input element disabled attribute */
@@ -69,8 +55,11 @@ export type SelectRootProps = {
   success?: boolean;
   /** The controlled value of the select. Should be used in conjunction with onValueChange */
   value?: string;
-} & ControlledOrUncontrolled &
-  SelectRootVariants;
+  /** The value of the select when initially rendered. Use when you do not need to control the state of the select. */
+  defaultValue?: string;
+  /** force overlay open */
+  open?: boolean;
+} & SelectRootVariants;
 
 export const SelectRoot = ({
   children,

--- a/ui/select/src/SelectContent.tsx
+++ b/ui/select/src/SelectContent.tsx
@@ -30,6 +30,18 @@ const scrollButtonStyles = {
   height: 25,
   backgroundColor: theme.colors["secondary"],
   cursor: "default",
+  variants: {
+    top: {
+      true: {
+        marginBlockStart: "-11px",
+      },
+    },
+    bottom: {
+      true: {
+        marginBlockEnd: "-11px",
+      },
+    },
+  },
 };
 
 const StyledScrollUpButton = styled(
@@ -66,13 +78,13 @@ export const SelectContent = React.forwardRef<
         {...props}
         ref={ref}
       >
-        <StyledScrollUpButton css={{ marginTop: "-11px" }}>
+        <StyledScrollUpButton top>
           <Icon label="">
             <ChevronUp />
           </Icon>
         </StyledScrollUpButton>
         <StyledViewport>{children}</StyledViewport>
-        <StyledScrollDownButton css={{ marginBottom: "-11px" }}>
+        <StyledScrollDownButton bottom>
           <Icon label="">
             <ChevronDown />
           </Icon>

--- a/ui/select/src/SelectContent.tsx
+++ b/ui/select/src/SelectContent.tsx
@@ -16,7 +16,8 @@ const StyledContent = styled(SelectPrimitive.Content, {
   fontSize: theme.fontSizes["100"],
   fontWeight: theme.fontWeights.light,
   lineHeight: theme.lineHeights["125"],
-  transform: "translate(22px, 9px)",
+  paddingBlock: "11px",
+  transform: "translateX(22px)",
   overflowWrap: "anywhere",
 });
 
@@ -65,13 +66,13 @@ export const SelectContent = React.forwardRef<
         {...props}
         ref={ref}
       >
-        <StyledScrollUpButton>
+        <StyledScrollUpButton css={{ marginTop: "-11px" }}>
           <Icon label="">
             <ChevronUp />
           </Icon>
         </StyledScrollUpButton>
         <StyledViewport>{children}</StyledViewport>
-        <StyledScrollDownButton>
+        <StyledScrollDownButton css={{ marginBottom: "-11px" }}>
           <Icon label="">
             <ChevronDown />
           </Icon>

--- a/ui/select/src/SelectItem.tsx
+++ b/ui/select/src/SelectItem.tsx
@@ -33,12 +33,16 @@ const StyledItemIndicator = styled(SelectPrimitive.ItemIndicator, {
   position: "absolute",
   left: theme.sizes["050"],
   width: theme.sizes[100],
+  height: theme.sizes[100],
   display: "inline-flex",
   alignItems: "center",
   justifyContent: "center",
 });
 
-const StyledCheck = styled(Check, {});
+const StyledCheck = styled(Check, {
+  width: "100%",
+  height: "100%",
+});
 
 export type SelectItemProps = {
   /** Used to insert select elements into the root component*/

--- a/ui/select/src/play.stories.tsx
+++ b/ui/select/src/play.stories.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import { Select } from "./";
 
+import type { ComponentStory } from "@storybook/react";
+
 export default {
   title: "Select",
   component: Select.Root,
@@ -14,7 +16,7 @@ export default {
   },
 };
 
-const Template = (args) => {
+const Template: ComponentStory<typeof Select.Root> = (args) => {
   return (
     <Select.Root {...args} defaultValue="ecuador">
       <Select.Trigger aria-label="Countries">
@@ -54,5 +56,34 @@ Play.args = {
 Play.storyName = "Select";
 
 Play.parameters = {
+  chromatic: { disableSnapshot: true },
+};
+
+const ControlledTemplate: ComponentStory<typeof Select.Root> = (args) => {
+  const [country, setCountry] = React.useState("spain");
+  function handleValueChange(val) {
+    setCountry(val);
+  }
+  return (
+    <Select.Root {...args} value={country} onValueChange={handleValueChange}>
+      <Select.Trigger aria-label="Countries">
+        <Select.Label>Countries</Select.Label>
+        <Select.Value />
+      </Select.Trigger>
+      <Select.Content>
+        <Select.Item value="france">France</Select.Item>
+        <Select.Item value="united-kingdom">United Kingdom</Select.Item>
+        <Select.Item value="spain">Spain</Select.Item>
+        <Select.Item value="peru">Peru</Select.Item>
+        <Select.Item value="chile">Chile</Select.Item>
+        <Select.Item value="ecuador">Ecuador</Select.Item>
+      </Select.Content>
+    </Select.Root>
+  );
+};
+
+export const Controlled = ControlledTemplate.bind({});
+
+Controlled.parameters = {
   chromatic: { disableSnapshot: true },
 };


### PR DESCRIPTION
## What I did

This PR updates the mobile layout of the docs site to allow Select to be used. When the Select was rendered off-screen it was outside the container element and was un-clickable on mobile.

This should be a special case unique to our layout, offscreen rendering was tested and validated to work in other cases.

In addition, there are some small tweaks to Select to improve its display and TypeScript support
