### PR TITLE
fix: changed import style to fix missing api table

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,6 +37,14 @@ module.exports = {
       rules: {
         "react/prop-types": "off",
         "@washingtonpost/wpds/theme-colors": "warn",
+        "no-restricted-syntax": [
+          "error",
+          {
+            selector:
+              "ImportDeclaration[source.value='react'][specifiers.0.type='ImportDefaultSpecifier']",
+            message: "Default React import not allowed",
+          },
+        ],
       },
     },
   ],

--- a/build.washingtonpost.com/pages/working-examples/index.tsx
+++ b/build.washingtonpost.com/pages/working-examples/index.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import * as React from "react";
+import { useState } from "react";
 import { useForm, Controller } from "react-hook-form";
 import { isPossiblePhoneNumber } from "react-phone-number-input";
 import {

--- a/ui/input-text/src/InputText.tsx
+++ b/ui/input-text/src/InputText.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from "react";
+import * as React from "react";
+import { useEffect, useState } from "react";
 import { nanoid } from "nanoid";
 import { theme, styled } from "@washingtonpost/wpds-theme";
 import { Button } from "@washingtonpost/wpds-button";
@@ -139,8 +140,6 @@ export const InputText = React.forwardRef<HTMLInputElement, InputTextProps>(
     },
     ref
   ) => {
-    globalInputAutoFillTriggerAnimations();
-
     const [helperId, setHelperId] = useState<string | undefined>();
     const [errorId, setErrorId] = useState<string | undefined>();
     const [isAutofilled, setIsAutofilled] = useState<boolean>(false);
@@ -163,6 +162,7 @@ export const InputText = React.forwardRef<HTMLInputElement, InputTextProps>(
     }, [ref, internalRef]);
 
     useEffect(() => {
+      globalInputAutoFillTriggerAnimations();
       const element = internalRef.current;
 
       const onAnimationStart = (e) => {
@@ -179,7 +179,7 @@ export const InputText = React.forwardRef<HTMLInputElement, InputTextProps>(
       return () => {
         element?.removeEventListener("animationstart", onAnimationStart, false);
       };
-    });
+    }, []);
 
     const [isFloating, handleOnFocus, handleOnBlur, handleOnChange] =
       useFloating(

--- a/ui/input-textarea/src/InputTextarea.tsx
+++ b/ui/input-textarea/src/InputTextarea.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useEffect, useState } from "react";
 import { nanoid } from "nanoid";
 import { theme, css, styled } from "@washingtonpost/wpds-theme";
 import type * as WPDS from "@washingtonpost/wpds-theme";
@@ -11,8 +12,6 @@ import {
 import { InputLabel } from "@washingtonpost/wpds-input-label";
 import { ErrorMessage } from "@washingtonpost/wpds-error-message";
 import { HelperText } from "@washingtonpost/wpds-helper-text";
-
-import { useEffect, useState } from "react";
 
 const NAME = "InputTextarea";
 
@@ -122,8 +121,6 @@ export const InputTextarea = React.forwardRef<
     },
     ref
   ) => {
-    globalInputAutoFillTriggerAnimations();
-
     const [helperId, setHelperId] = useState<string | undefined>();
     const [errorId, setErrorId] = useState<string | undefined>();
     const [isAutofilled, setIsAutofilled] = useState<boolean>(false);
@@ -147,10 +144,10 @@ export const InputTextarea = React.forwardRef<
     }, [ref, internalRef]);
 
     useEffect(() => {
+      globalInputAutoFillTriggerAnimations();
       const element = internalRef.current;
 
       const onAnimationStart = (e) => {
-        console.log(e.animationName);
         switch (e.animationName) {
           case "jsTriggerAutoFillStart":
             return setIsAutofilled(true);
@@ -164,7 +161,7 @@ export const InputTextarea = React.forwardRef<
       return () => {
         element?.removeEventListener("animationstart", onAnimationStart, false);
       };
-    });
+    }, []);
 
     const [isFloating, handleFocus, handleBlur, handleChange] = useFloating(
       value || defaultValue || placeholder || isAutofilled,


### PR DESCRIPTION
## What I did

This PR changes the import of React to make API tables work. This is a known issue in `react-typescript-docgen` https://github.com/styleguidist/react-docgen-typescript/issues/323 

WPDS-1293


[WPDS-1293]: https://arcpublishing.atlassian.net/browse/WPDS-1293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ