### PR TITLE
fix: allow passing in checkbox label as child

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11740,13 +11740,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.28.0.tgz",
-      "integrity": "sha512-vrHs5DFTPwYox5SGKq/7TDn/S4q6RA1zArd7uhO6EyP9hj3XgZBBM12ktMbnDQNxh/fL1IUKsTNLxihmsU38lQ==",
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.29.1.tgz",
+      "integrity": "sha512-iQxk2DX5U9wOGV3+/Jh9OHPsw5H3mleUL2S4BgQuwtlAfK3PnKvn38m4Rg9zIViGHVW24opSm99HQm/UFLEy6w==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.28.0"
+        "playwright-core": "1.29.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -11756,9 +11756,9 @@
       }
     },
     "node_modules/@playwright/test/node_modules/playwright-core": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.28.0.tgz",
-      "integrity": "sha512-nJLknd28kPBiCNTbqpu6Wmkrh63OEqJSFw9xOfL9qxfNwody7h6/L3O2dZoWQ6Oxcm0VOHjWmGiCUGkc0X3VZA==",
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.29.1.tgz",
+      "integrity": "sha512-20Ai3d+lMkWpI9YZYlxk8gxatfgax5STW8GaMozAHwigLiyiKQrdkt7gaoT9UQR8FIVDg6qVXs9IoZUQrDjIIg==",
       "dev": true,
       "bin": {
         "playwright": "cli.js"
@@ -62309,19 +62309,19 @@
       }
     },
     "@playwright/test": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.28.0.tgz",
-      "integrity": "sha512-vrHs5DFTPwYox5SGKq/7TDn/S4q6RA1zArd7uhO6EyP9hj3XgZBBM12ktMbnDQNxh/fL1IUKsTNLxihmsU38lQ==",
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.29.1.tgz",
+      "integrity": "sha512-iQxk2DX5U9wOGV3+/Jh9OHPsw5H3mleUL2S4BgQuwtlAfK3PnKvn38m4Rg9zIViGHVW24opSm99HQm/UFLEy6w==",
       "dev": true,
       "requires": {
         "@types/node": "*",
-        "playwright-core": "1.28.0"
+        "playwright-core": "1.29.1"
       },
       "dependencies": {
         "playwright-core": {
-          "version": "1.28.0",
-          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.28.0.tgz",
-          "integrity": "sha512-nJLknd28kPBiCNTbqpu6Wmkrh63OEqJSFw9xOfL9qxfNwody7h6/L3O2dZoWQ6Oxcm0VOHjWmGiCUGkc0X3VZA==",
+          "version": "1.29.1",
+          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.29.1.tgz",
+          "integrity": "sha512-20Ai3d+lMkWpI9YZYlxk8gxatfgax5STW8GaMozAHwigLiyiKQrdkt7gaoT9UQR8FIVDg6qVXs9IoZUQrDjIIg==",
           "dev": true
         }
       }

--- a/ui/checkbox/src/Checkbox.tsx
+++ b/ui/checkbox/src/Checkbox.tsx
@@ -298,7 +298,7 @@ export const Checkbox = React.forwardRef<HTMLButtonElement, CheckboxInterface>(
             </StyledCheck>
           </StyledIndicator>
         </StyledCheckbox>
-        {props.label}
+        {props.label || props.children}
       </StyledInputLabel>
     );
   }

--- a/ui/checkbox/src/play.stories.jsx
+++ b/ui/checkbox/src/play.stories.jsx
@@ -162,6 +162,9 @@ const ChromaticTemplate = () => (
         id="l1"
       />
       <Component variant="primary" label="Checkbox 2" id="l2" />
+      <Component variant="primary" id="l3">
+        Checkbox 3
+      </Component>
     </HStack>
     <HStack>
       <Component


### PR DESCRIPTION
## What I did

You can now pass in the label as a component child, not just as a label prop.

`<Checkbox label="Checkbox Label"/>`
`<Checkbox>Checkbox Label</Checkbox>`