### PR TITLE
feat: remove padding from inline alert on Popover docs

### DIFF
--- a/build.washingtonpost.com/docs/components/popover.mdx
+++ b/build.washingtonpost.com/docs/components/popover.mdx
@@ -28,11 +28,15 @@ status: "Draft"
 The Popover can be positioned top, left, right, and bottom with each having ability to be positioned at the start, center, or end of the trigger.
 
 <AlertBanner.Root css={{ marginBottom: "$200" }} variant="information">
-  <AlertBanner.Content>
-    <b>Note:</b> This option sets the preferred position of the popover to
-    render against when open. Will be reversed when collisions occur with other
-    elements.
-  </AlertBanner.Content>
+  <AlertBanner.Content
+    children={
+      <>
+        <b>Note:</b> This option sets the preferred position of the popover to
+        render against when open. Will be reversed when collisions occur with
+        other elements.
+      </>
+    }
+  />
 </AlertBanner.Root>
 
 ```jsx withPreview


### PR DESCRIPTION
## What I did

Removes unintended padding from inline alert
