### PR TITLE
feat: bump assets package to add new icons

### DIFF
--- a/build.washingtonpost.com/package.json
+++ b/build.washingtonpost.com/package.json
@@ -26,7 +26,7 @@
     "@washingtonpost/site-footer": "0.11.3",
     "@washingtonpost/site-third-party-scripts": "latest",
     "@washingtonpost/wpds-accordion": "*",
-    "@washingtonpost/wpds-assets": "^1.16.0",
+    "@washingtonpost/wpds-assets": "^1.17.0",
     "@washingtonpost/wpds-ui-kit": "*",
     "fuse.js": "^6.6.2",
     "gray-matter": "^4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -114,7 +114,7 @@
         "@washingtonpost/site-footer": "0.11.3",
         "@washingtonpost/site-third-party-scripts": "latest",
         "@washingtonpost/wpds-accordion": "*",
-        "@washingtonpost/wpds-assets": "^1.16.0",
+        "@washingtonpost/wpds-assets": "^1.17.0",
         "@washingtonpost/wpds-ui-kit": "*",
         "fuse.js": "^6.6.2",
         "gray-matter": "^4.0.2",
@@ -566,9 +566,9 @@
       }
     },
     "build.washingtonpost.com/node_modules/@washingtonpost/wpds-assets": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-assets/-/wpds-assets-1.16.0.tgz",
-      "integrity": "sha512-pBBCClPQsVxKNRykx1IegRf/F7NPGq2dt+YO4fHUPSpsZQ0rtwK1lpU3BbX9AFl0nTewff01BeMGAkUg6NQWQw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-assets/-/wpds-assets-1.17.0.tgz",
+      "integrity": "sha512-IdVsntS9qE9xyXUpgDxFRfwqThzCM9PwS1uPSOXQzFQaWP5ysVdLZ9YPYFaaYffCOSjKJX9/Apv1VvxjJmX14Q==",
       "dependencies": {
         "react": "^16.0.1 || ^17.0.2",
         "react-dom": "^16.0.1 || ^17.0.2"
@@ -64956,7 +64956,7 @@
         "@washingtonpost/site-footer": "0.11.3",
         "@washingtonpost/site-third-party-scripts": "latest",
         "@washingtonpost/wpds-accordion": "*",
-        "@washingtonpost/wpds-assets": "^1.16.0",
+        "@washingtonpost/wpds-assets": "1.17.0",
         "@washingtonpost/wpds-ui-kit": "*",
         "babel-plugin-extract-react-types": "^0.1.14",
         "eslint": "8.6.0",
@@ -65276,9 +65276,9 @@
           }
         },
         "@washingtonpost/wpds-assets": {
-          "version": "1.16.0",
-          "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-assets/-/wpds-assets-1.16.0.tgz",
-          "integrity": "sha512-pBBCClPQsVxKNRykx1IegRf/F7NPGq2dt+YO4fHUPSpsZQ0rtwK1lpU3BbX9AFl0nTewff01BeMGAkUg6NQWQw==",
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-assets/-/wpds-assets-1.17.0.tgz",
+          "integrity": "sha512-IdVsntS9qE9xyXUpgDxFRfwqThzCM9PwS1uPSOXQzFQaWP5ysVdLZ9YPYFaaYffCOSjKJX9/Apv1VvxjJmX14Q==",
           "requires": {
             "react": "^16.0.1 || ^17.0.2",
             "react-dom": "^16.0.1 || ^17.0.2"


### PR DESCRIPTION
## What I did

This PR bumps the version of the assets package to include the On the Record, Pin, and eBook icons