### PR TITLE
fix: update build and dev scripts in Popover to use legacy output flag

### DIFF
--- a/templates/component/package.json.hbs
+++ b/templates/component/package.json.hbs
@@ -24,8 +24,8 @@
 	},
 	"scripts": {
 		"test": "echo \"Error: run tests from root\" && exit 1",
-		"build": "tsup src/index.ts --loader .ts=tsx --minify --format esm,cjs --dts --sourcemap --external react",
-		"dev": "tsup src/index.ts --format esm,cjs --watch --dts --external react",
+		"build": "tsup src/index.ts --loader .ts=tsx --minify --format esm,cjs --dts --sourcemap --legacy-output --external react",
+		"dev": "tsup src/index.ts --format esm,cjs --watch --dts --legacy-output --external react",
     	"clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
 	},
 	"bugs": {

--- a/ui/popover/package.json
+++ b/ui/popover/package.json
@@ -24,8 +24,8 @@
   },
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",
-    "build": "tsup src/index.ts --loader .ts=tsx --minify --format esm,cjs --dts --sourcemap --external react",
-    "dev": "tsup src/index.ts --format esm,cjs --watch --dts --external react",
+    "build": "tsup src/index.ts --loader .ts=tsx --minify --format esm,cjs --dts --sourcemap --legacy-output --external react",
+    "dev": "tsup src/index.ts --format esm,cjs --watch --dts --legacy-output --external react",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },
   "bugs": {


### PR DESCRIPTION
## What I did

This PR adds the `--legacy-output` flag to Popover and updates the component template file as well.
