### PR TITLE
fix: update prettier to fix build

### DIFF
--- a/build.washingtonpost.com/next.config.js
+++ b/build.washingtonpost.com/next.config.js
@@ -96,7 +96,8 @@ module.exports = withBundleAnalyzer({
       },
       {
         source: "/storybook",
-        destination: "https://wpds-ui-kit-storybook.preview.now.washingtonpost.com",
+        destination:
+          "https://wpds-ui-kit-storybook.preview.now.washingtonpost.com",
         permanent: false,
       },
     ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,7 +106,7 @@
     },
     "build.washingtonpost.com": {
       "name": "@washingtonpost/wpds-docs",
-      "version": "0.23.2",
+      "version": "0.24.0",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/standalone": "^7.17.11",
@@ -122,9 +122,9 @@
         "@washingtonpost/site-components": "7.14.3",
         "@washingtonpost/site-footer": "0.11.3",
         "@washingtonpost/site-third-party-scripts": "latest",
-        "@washingtonpost/wpds-accordion": "*",
+        "@washingtonpost/wpds-accordion": "0.24.0",
         "@washingtonpost/wpds-assets": "^1.17.0",
-        "@washingtonpost/wpds-ui-kit": "*",
+        "@washingtonpost/wpds-ui-kit": "0.24.0",
         "fuse.js": "^6.6.2",
         "gray-matter": "^4.0.2",
         "lz-string": "^1.4.4",
@@ -541,24 +541,6 @@
         "prop-types": "^15.7.2"
       }
     },
-    "build.washingtonpost.com/node_modules/@washingtonpost/wpds-accordion": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-accordion/-/wpds-accordion-0.17.0.tgz",
-      "integrity": "sha512-vbDzTQ/A1atTa8Rpzo6Vz5EOuheyiUVnk33lZfeo58aXY2eDys4N180VeZPFKOlMkJv7237W573deP8Zh1LFSA==",
-      "dependencies": {
-        "@radix-ui/react-accordion": "latest",
-        "@washingtonpost/wpds-assets": "*",
-        "@washingtonpost/wpds-icon": "0.17.0",
-        "@washingtonpost/wpds-theme": "0.17.0"
-      },
-      "peerDependencies": {
-        "@radix-ui/react-accordion": "latest",
-        "@washingtonpost/wpds-assets": "*",
-        "@washingtonpost/wpds-icon": "*",
-        "@washingtonpost/wpds-theme": "*",
-        "react": "^16.8.6 || ^17.0.2"
-      }
-    },
     "build.washingtonpost.com/node_modules/@washingtonpost/wpds-assets": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-assets/-/wpds-assets-1.17.0.tgz",
@@ -570,45 +552,6 @@
       "peerDependencies": {
         "react": "^16.0.1 || ^17.0.2",
         "react-dom": "^16.0.1 || ^17.0.2"
-      }
-    },
-    "build.washingtonpost.com/node_modules/@washingtonpost/wpds-icon": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-icon/-/wpds-icon-0.17.0.tgz",
-      "integrity": "sha512-nXEDWRoGt+v4n/9tVj41hfy0GXWX5+xsxT/31NN5upmRAiN114VCVA3YhADYuXSsfDsz/zsiCjvk6jtskPzXNA==",
-      "dependencies": {
-        "@washingtonpost/wpds-theme": "0.17.0",
-        "@washingtonpost/wpds-visually-hidden": "0.17.0",
-        "react": "^16.8.6 || ^17.0.2"
-      },
-      "peerDependencies": {
-        "@washingtonpost/wpds-theme": "*",
-        "@washingtonpost/wpds-visually-hidden": "*",
-        "react": "^16.8.6 || ^17.0.2"
-      }
-    },
-    "build.washingtonpost.com/node_modules/@washingtonpost/wpds-theme": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-theme/-/wpds-theme-0.17.0.tgz",
-      "integrity": "sha512-zgwt7QpKS5kpmPIQ3hxhBXJ6SUN3weUYu+l+errrZOR5eJnIlRSnO+8eHWsVrgcFP8BEWA+kNFKVNjOe4zhhAg==",
-      "dependencies": {
-        "@stitches/react": "*"
-      },
-      "peerDependencies": {
-        "@stitches/react": "*"
-      }
-    },
-    "build.washingtonpost.com/node_modules/@washingtonpost/wpds-visually-hidden": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-visually-hidden/-/wpds-visually-hidden-0.17.0.tgz",
-      "integrity": "sha512-cfHPzLRFihRao+cleH7hlN7yid4mx9q/yPKwp8gPsxLbah2A5QNHtLAYacAvVvDaX0m7IWdnw1EdFXTDPgqfEQ==",
-      "dependencies": {
-        "@washingtonpost/wpds-theme": "0.17.0",
-        "react": "^16.8.6 || ^17.0.2"
-      },
-      "peerDependencies": {
-        "@washingtonpost/wpds-theme": "*",
-        "react": "^16.8.6 || ^17.0.2"
       }
     },
     "build.washingtonpost.com/node_modules/ajv": {
@@ -47458,13 +47401,13 @@
     },
     "ui/accordion": {
       "name": "@washingtonpost/wpds-accordion",
-      "version": "0.23.2",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-accordion": "latest",
         "@washingtonpost/wpds-assets": "^1.16.0",
-        "@washingtonpost/wpds-icon": "0.23.2",
-        "@washingtonpost/wpds-theme": "0.23.2"
+        "@washingtonpost/wpds-icon": "0.24.0",
+        "@washingtonpost/wpds-theme": "0.24.0"
       },
       "devDependencies": {
         "tsup": "^5.11.13",
@@ -47506,15 +47449,15 @@
     },
     "ui/alert-banner": {
       "name": "@washingtonpost/wpds-alert-banner",
-      "version": "0.23.2",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-app-bar": "0.23.2",
+        "@washingtonpost/wpds-app-bar": "0.24.0",
         "@washingtonpost/wpds-assets": "^1.16.0",
-        "@washingtonpost/wpds-button": "0.23.2",
-        "@washingtonpost/wpds-container": "0.23.2",
-        "@washingtonpost/wpds-icon": "0.23.2",
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-button": "0.24.0",
+        "@washingtonpost/wpds-container": "0.24.0",
+        "@washingtonpost/wpds-icon": "0.24.0",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {
@@ -47559,10 +47502,10 @@
     },
     "ui/app-bar": {
       "name": "@washingtonpost/wpds-app-bar",
-      "version": "0.23.2",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {
@@ -47589,11 +47532,11 @@
     },
     "ui/avatar": {
       "name": "@washingtonpost/wpds-avatar",
-      "version": "0.23.2",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-avatar": "latest",
-        "@washingtonpost/wpds-theme": "0.23.2"
+        "@washingtonpost/wpds-theme": "0.24.0"
       },
       "devDependencies": {
         "tsup": "^5.11.13",
@@ -47620,10 +47563,10 @@
     },
     "ui/box": {
       "name": "@washingtonpost/wpds-box",
-      "version": "0.23.2",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {
@@ -47650,10 +47593,10 @@
     },
     "ui/button": {
       "name": "@washingtonpost/wpds-button",
-      "version": "0.23.2",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {
@@ -47680,10 +47623,10 @@
     },
     "ui/card": {
       "name": "@washingtonpost/wpds-card",
-      "version": "0.23.2",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "0.23.2"
+        "@washingtonpost/wpds-theme": "0.24.0"
       },
       "devDependencies": {
         "tsup": "^5.11.13",
@@ -47709,15 +47652,15 @@
     },
     "ui/checkbox": {
       "name": "@washingtonpost/wpds-checkbox",
-      "version": "0.23.2",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-checkbox": "latest",
         "@washingtonpost/wpds-assets": "^1.16.0",
-        "@washingtonpost/wpds-icon": "0.23.2",
-        "@washingtonpost/wpds-input-shared": "0.23.2",
-        "@washingtonpost/wpds-theme": "0.23.2",
-        "@washingtonpost/wpds-visually-hidden": "0.23.2",
+        "@washingtonpost/wpds-icon": "0.24.0",
+        "@washingtonpost/wpds-input-shared": "0.24.0",
+        "@washingtonpost/wpds-theme": "0.24.0",
+        "@washingtonpost/wpds-visually-hidden": "0.24.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {
@@ -47762,10 +47705,10 @@
     },
     "ui/container": {
       "name": "@washingtonpost/wpds-container",
-      "version": "0.23.2",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {
@@ -47792,11 +47735,11 @@
     },
     "ui/divider": {
       "name": "@washingtonpost/wpds-divider",
-      "version": "0.23.2",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-separator": "^1.0.0",
-        "@washingtonpost/wpds-theme": "0.23.2"
+        "@washingtonpost/wpds-theme": "0.24.0"
       },
       "devDependencies": {
         "tsup": "^5.11.13",
@@ -47871,15 +47814,15 @@
     },
     "ui/drawer": {
       "name": "@washingtonpost/wpds-drawer",
-      "version": "0.23.2",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-focus-scope": "^1.0.0",
         "@washingtonpost/wpds-assets": "^1.16.0",
-        "@washingtonpost/wpds-button": "0.23.2",
-        "@washingtonpost/wpds-icon": "0.23.2",
-        "@washingtonpost/wpds-scrim": "0.23.2",
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-button": "0.24.0",
+        "@washingtonpost/wpds-icon": "0.24.0",
+        "@washingtonpost/wpds-scrim": "0.24.0",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "react-transition-group": "^4.4.5"
       },
       "devDependencies": {
@@ -47923,10 +47866,10 @@
     },
     "ui/error-message": {
       "name": "@washingtonpost/wpds-error-message",
-      "version": "0.23.2",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "0.23.2"
+        "@washingtonpost/wpds-theme": "0.24.0"
       },
       "devDependencies": {
         "tsup": "^5.11.13",
@@ -47952,10 +47895,10 @@
     },
     "ui/eslint-plugin": {
       "name": "@washingtonpost/eslint-plugin-wpds",
-      "version": "0.23.2",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "0.23.2"
+        "@washingtonpost/wpds-theme": "0.24.0"
       },
       "devDependencies": {
         "jest": "^28.1.0"
@@ -48872,10 +48815,10 @@
     },
     "ui/fieldset": {
       "name": "@washingtonpost/wpds-fieldset",
-      "version": "0.23.2",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "0.23.2"
+        "@washingtonpost/wpds-theme": "0.24.0"
       },
       "devDependencies": {
         "tsup": "^5.11.13",
@@ -48901,10 +48844,10 @@
     },
     "ui/helper-text": {
       "name": "@washingtonpost/wpds-helper-text",
-      "version": "0.23.2",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "0.23.2"
+        "@washingtonpost/wpds-theme": "0.24.0"
       },
       "devDependencies": {
         "tsup": "^5.11.13",
@@ -48930,11 +48873,11 @@
     },
     "ui/icon": {
       "name": "@washingtonpost/wpds-icon",
-      "version": "0.23.2",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "0.23.2",
-        "@washingtonpost/wpds-visually-hidden": "0.23.2",
+        "@washingtonpost/wpds-theme": "0.24.0",
+        "@washingtonpost/wpds-visually-hidden": "0.24.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {
@@ -48962,12 +48905,12 @@
     },
     "ui/input-label": {
       "name": "@washingtonpost/wpds-input-label",
-      "version": "0.23.2",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-label": "^1.0.0",
-        "@washingtonpost/wpds-input-shared": "0.23.2",
-        "@washingtonpost/wpds-theme": "0.23.2"
+        "@washingtonpost/wpds-input-shared": "0.24.0",
+        "@washingtonpost/wpds-theme": "0.24.0"
       },
       "devDependencies": {
         "tsup": "^5.11.13",
@@ -49080,12 +49023,12 @@
     },
     "ui/input-password": {
       "name": "@washingtonpost/wpds-input-password",
-      "version": "0.23.2",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "@washingtonpost/wpds-assets": "^1.16.0",
-        "@washingtonpost/wpds-icon": "0.23.2",
-        "@washingtonpost/wpds-input-text": "0.23.2"
+        "@washingtonpost/wpds-icon": "0.24.0",
+        "@washingtonpost/wpds-input-text": "0.24.0"
       },
       "devDependencies": {
         "tsup": "^5.11.13",
@@ -49126,10 +49069,10 @@
     },
     "ui/input-shared": {
       "name": "@washingtonpost/wpds-input-shared",
-      "version": "0.23.2",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "0.23.2"
+        "@washingtonpost/wpds-theme": "0.24.0"
       },
       "devDependencies": {
         "tsup": "^5.11.13",
@@ -49155,20 +49098,20 @@
     },
     "ui/input-text": {
       "name": "@washingtonpost/wpds-input-text",
-      "version": "0.23.2",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-label": "^1.0.0",
         "@washingtonpost/wpds-assets": "^1.16.0",
-        "@washingtonpost/wpds-box": "0.23.2",
-        "@washingtonpost/wpds-button": "0.23.2",
-        "@washingtonpost/wpds-error-message": "0.23.2",
-        "@washingtonpost/wpds-helper-text": "0.23.2",
-        "@washingtonpost/wpds-icon": "0.23.2",
-        "@washingtonpost/wpds-input-label": "0.23.2",
-        "@washingtonpost/wpds-input-shared": "0.23.2",
-        "@washingtonpost/wpds-theme": "0.23.2",
-        "@washingtonpost/wpds-visually-hidden": "0.23.2",
+        "@washingtonpost/wpds-box": "0.24.0",
+        "@washingtonpost/wpds-button": "0.24.0",
+        "@washingtonpost/wpds-error-message": "0.24.0",
+        "@washingtonpost/wpds-helper-text": "0.24.0",
+        "@washingtonpost/wpds-icon": "0.24.0",
+        "@washingtonpost/wpds-input-label": "0.24.0",
+        "@washingtonpost/wpds-input-shared": "0.24.0",
+        "@washingtonpost/wpds-theme": "0.24.0",
+        "@washingtonpost/wpds-visually-hidden": "0.24.0",
         "nanoid": "^3.3.2"
       },
       "devDependencies": {
@@ -49313,14 +49256,14 @@
     },
     "ui/input-textarea": {
       "name": "@washingtonpost/wpds-input-textarea",
-      "version": "0.23.2",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-error-message": "0.23.2",
-        "@washingtonpost/wpds-helper-text": "0.23.2",
-        "@washingtonpost/wpds-input-label": "0.23.2",
-        "@washingtonpost/wpds-input-shared": "0.23.2",
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-error-message": "0.24.0",
+        "@washingtonpost/wpds-helper-text": "0.24.0",
+        "@washingtonpost/wpds-input-label": "0.24.0",
+        "@washingtonpost/wpds-input-shared": "0.24.0",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {
@@ -49351,38 +49294,38 @@
     },
     "ui/kit": {
       "name": "@washingtonpost/wpds-ui-kit",
-      "version": "0.23.2",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/eslint-plugin-wpds": "0.23.2",
-        "@washingtonpost/wpds-accordion": "0.23.2",
-        "@washingtonpost/wpds-alert-banner": "0.23.2",
-        "@washingtonpost/wpds-app-bar": "0.23.2",
-        "@washingtonpost/wpds-avatar": "0.23.2",
-        "@washingtonpost/wpds-box": "0.23.2",
-        "@washingtonpost/wpds-button": "0.23.2",
-        "@washingtonpost/wpds-card": "0.23.2",
-        "@washingtonpost/wpds-checkbox": "0.23.2",
-        "@washingtonpost/wpds-container": "0.23.2",
-        "@washingtonpost/wpds-divider": "0.23.2",
-        "@washingtonpost/wpds-drawer": "0.23.2",
-        "@washingtonpost/wpds-error-message": "0.23.2",
-        "@washingtonpost/wpds-fieldset": "0.23.2",
-        "@washingtonpost/wpds-helper-text": "0.23.2",
-        "@washingtonpost/wpds-icon": "0.23.2",
-        "@washingtonpost/wpds-input-label": "0.23.2",
-        "@washingtonpost/wpds-input-password": "0.23.2",
-        "@washingtonpost/wpds-input-shared": "0.23.2",
-        "@washingtonpost/wpds-input-text": "0.23.2",
-        "@washingtonpost/wpds-input-textarea": "0.23.2",
-        "@washingtonpost/wpds-pagination-dots": "0.23.2",
-        "@washingtonpost/wpds-popover": "0.23.2",
-        "@washingtonpost/wpds-radio-group": "0.23.2",
-        "@washingtonpost/wpds-scrim": "0.23.2",
-        "@washingtonpost/wpds-select": "0.23.2",
-        "@washingtonpost/wpds-theme": "0.23.2",
-        "@washingtonpost/wpds-tooltip": "0.23.2",
-        "@washingtonpost/wpds-visually-hidden": "0.23.2"
+        "@washingtonpost/eslint-plugin-wpds": "0.24.0",
+        "@washingtonpost/wpds-accordion": "0.24.0",
+        "@washingtonpost/wpds-alert-banner": "0.24.0",
+        "@washingtonpost/wpds-app-bar": "0.24.0",
+        "@washingtonpost/wpds-avatar": "0.24.0",
+        "@washingtonpost/wpds-box": "0.24.0",
+        "@washingtonpost/wpds-button": "0.24.0",
+        "@washingtonpost/wpds-card": "0.24.0",
+        "@washingtonpost/wpds-checkbox": "0.24.0",
+        "@washingtonpost/wpds-container": "0.24.0",
+        "@washingtonpost/wpds-divider": "0.24.0",
+        "@washingtonpost/wpds-drawer": "0.24.0",
+        "@washingtonpost/wpds-error-message": "0.24.0",
+        "@washingtonpost/wpds-fieldset": "0.24.0",
+        "@washingtonpost/wpds-helper-text": "0.24.0",
+        "@washingtonpost/wpds-icon": "0.24.0",
+        "@washingtonpost/wpds-input-label": "0.24.0",
+        "@washingtonpost/wpds-input-password": "0.24.0",
+        "@washingtonpost/wpds-input-shared": "0.24.0",
+        "@washingtonpost/wpds-input-text": "0.24.0",
+        "@washingtonpost/wpds-input-textarea": "0.24.0",
+        "@washingtonpost/wpds-pagination-dots": "0.24.0",
+        "@washingtonpost/wpds-popover": "0.24.0",
+        "@washingtonpost/wpds-radio-group": "0.24.0",
+        "@washingtonpost/wpds-scrim": "0.24.0",
+        "@washingtonpost/wpds-select": "0.24.0",
+        "@washingtonpost/wpds-theme": "0.24.0",
+        "@washingtonpost/wpds-tooltip": "0.24.0",
+        "@washingtonpost/wpds-visually-hidden": "0.24.0"
       },
       "devDependencies": {
         "tsup": "^5.11.13",
@@ -49435,10 +49378,10 @@
     },
     "ui/pagination-dots": {
       "name": "@washingtonpost/wpds-pagination-dots",
-      "version": "0.23.2",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "0.23.2"
+        "@washingtonpost/wpds-theme": "0.24.0"
       },
       "devDependencies": {
         "tsup": "^5.11.13",
@@ -49464,14 +49407,14 @@
     },
     "ui/popover": {
       "name": "@washingtonpost/wpds-popover",
-      "version": "0.23.2",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-popover": "^1.0.2",
         "@washingtonpost/wpds-assets": "*",
-        "@washingtonpost/wpds-button": "0.23.2",
-        "@washingtonpost/wpds-icon": "0.23.2",
-        "@washingtonpost/wpds-theme": "0.23.2"
+        "@washingtonpost/wpds-button": "0.24.0",
+        "@washingtonpost/wpds-icon": "0.24.0",
+        "@washingtonpost/wpds-theme": "0.24.0"
       },
       "devDependencies": {
         "tsup": "^5.11.13",
@@ -49497,14 +49440,14 @@
     },
     "ui/radio-group": {
       "name": "@washingtonpost/wpds-radio-group",
-      "version": "0.23.2",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-radio-group": "^1.0.0",
-        "@washingtonpost/wpds-error-message": "0.23.2",
-        "@washingtonpost/wpds-fieldset": "0.23.2",
-        "@washingtonpost/wpds-input-label": "0.23.2",
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-error-message": "0.24.0",
+        "@washingtonpost/wpds-fieldset": "0.24.0",
+        "@washingtonpost/wpds-input-label": "0.24.0",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "nanoid": "^3.3.3"
       },
       "devDependencies": {
@@ -49719,11 +49662,11 @@
     },
     "ui/scrim": {
       "name": "@washingtonpost/wpds-scrim",
-      "version": "0.23.2",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.0.0",
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "react-transition-group": "^4.4.5"
       },
       "devDependencies": {
@@ -49750,17 +49693,17 @@
     },
     "ui/select": {
       "name": "@washingtonpost/wpds-select",
-      "version": "0.23.2",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-select": "^1.0.0",
         "@radix-ui/react-use-controllable-state": "^1.0.0",
         "@washingtonpost/wpds-assets": "*",
-        "@washingtonpost/wpds-divider": "0.23.2",
-        "@washingtonpost/wpds-icon": "0.23.2",
-        "@washingtonpost/wpds-input-label": "0.23.2",
-        "@washingtonpost/wpds-input-shared": "0.23.2",
-        "@washingtonpost/wpds-theme": "0.23.2"
+        "@washingtonpost/wpds-divider": "0.24.0",
+        "@washingtonpost/wpds-icon": "0.24.0",
+        "@washingtonpost/wpds-input-label": "0.24.0",
+        "@washingtonpost/wpds-input-shared": "0.24.0",
+        "@washingtonpost/wpds-theme": "0.24.0"
       },
       "devDependencies": {
         "tsup": "^5.11.13",
@@ -49793,7 +49736,7 @@
     },
     "ui/theme": {
       "name": "@washingtonpost/wpds-theme",
-      "version": "0.23.2",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "@stitches/react": "^1.2.8"
@@ -49818,11 +49761,11 @@
     },
     "ui/tooltip": {
       "name": "@washingtonpost/wpds-tooltip",
-      "version": "0.23.2",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-tooltip": "^1.0.0",
-        "@washingtonpost/wpds-theme": "0.23.2"
+        "@washingtonpost/wpds-theme": "0.24.0"
       },
       "devDependencies": {
         "tsup": "^5.11.13",
@@ -49849,10 +49792,10 @@
     },
     "ui/visually-hidden": {
       "name": "@washingtonpost/wpds-visually-hidden",
-      "version": "0.23.2",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {
@@ -63492,7 +63435,7 @@
     "@washingtonpost/eslint-plugin-wpds": {
       "version": "file:ui/eslint-plugin",
       "requires": {
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "jest": "^28.1.0"
       },
       "dependencies": {
@@ -64475,8 +64418,8 @@
       "requires": {
         "@radix-ui/react-accordion": "latest",
         "@washingtonpost/wpds-assets": "^1.16.0",
-        "@washingtonpost/wpds-icon": "0.23.2",
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-icon": "0.24.0",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
       },
@@ -64501,12 +64444,12 @@
     "@washingtonpost/wpds-alert-banner": {
       "version": "file:ui/alert-banner",
       "requires": {
-        "@washingtonpost/wpds-app-bar": "0.23.2",
+        "@washingtonpost/wpds-app-bar": "0.24.0",
         "@washingtonpost/wpds-assets": "^1.16.0",
-        "@washingtonpost/wpds-button": "0.23.2",
-        "@washingtonpost/wpds-container": "0.23.2",
-        "@washingtonpost/wpds-icon": "0.23.2",
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-button": "0.24.0",
+        "@washingtonpost/wpds-container": "0.24.0",
+        "@washingtonpost/wpds-icon": "0.24.0",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "react": "^16.8.6 || ^17.0.2",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
@@ -64532,7 +64475,7 @@
     "@washingtonpost/wpds-app-bar": {
       "version": "file:ui/app-bar",
       "requires": {
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "react": "^16.8.6 || ^17.0.2",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
@@ -64559,7 +64502,7 @@
       "version": "file:ui/avatar",
       "requires": {
         "@radix-ui/react-avatar": "latest",
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
       },
@@ -64575,7 +64518,7 @@
     "@washingtonpost/wpds-box": {
       "version": "file:ui/box",
       "requires": {
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "react": "^16.8.6 || ^17.0.2",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
@@ -64592,7 +64535,7 @@
     "@washingtonpost/wpds-button": {
       "version": "file:ui/button",
       "requires": {
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "react": "^16.8.6 || ^17.0.2",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
@@ -64609,7 +64552,7 @@
     "@washingtonpost/wpds-card": {
       "version": "file:ui/card",
       "requires": {
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
       },
@@ -64627,10 +64570,10 @@
       "requires": {
         "@radix-ui/react-checkbox": "latest",
         "@washingtonpost/wpds-assets": "^1.16.0",
-        "@washingtonpost/wpds-icon": "0.23.2",
-        "@washingtonpost/wpds-input-shared": "0.23.2",
-        "@washingtonpost/wpds-theme": "0.23.2",
-        "@washingtonpost/wpds-visually-hidden": "0.23.2",
+        "@washingtonpost/wpds-icon": "0.24.0",
+        "@washingtonpost/wpds-input-shared": "0.24.0",
+        "@washingtonpost/wpds-theme": "0.24.0",
+        "@washingtonpost/wpds-visually-hidden": "0.24.0",
         "react": "^16.8.6 || ^17.0.2",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
@@ -64656,7 +64599,7 @@
     "@washingtonpost/wpds-container": {
       "version": "file:ui/container",
       "requires": {
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "react": "^16.8.6 || ^17.0.2",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
@@ -64674,7 +64617,7 @@
       "version": "file:ui/divider",
       "requires": {
         "@radix-ui/react-separator": "^1.0.0",
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
       },
@@ -64743,9 +64686,9 @@
         "@washingtonpost/site-components": "7.14.3",
         "@washingtonpost/site-footer": "0.11.3",
         "@washingtonpost/site-third-party-scripts": "latest",
-        "@washingtonpost/wpds-accordion": "*",
-        "@washingtonpost/wpds-assets": "1.17.0",
-        "@washingtonpost/wpds-ui-kit": "*",
+        "@washingtonpost/wpds-accordion": "0.24.0",
+        "@washingtonpost/wpds-assets": "^1.17.0",
+        "@washingtonpost/wpds-ui-kit": "0.24.0",
         "babel-plugin-extract-react-types": "^0.1.14",
         "eslint": "8.6.0",
         "eslint-config-next": "^12.2.4",
@@ -65046,17 +64989,6 @@
           "resolved": "https://registry.npmjs.org/@washingtonpost/site-third-party-scripts/-/site-third-party-scripts-0.3.3.tgz",
           "integrity": "sha512-zTi53GIDqG0qsIs+xy2tLAocpC5xfNyHhgCsG6GUmDOCwj/Yb/AfK/sT1J/wCb1ZjHiIIZL5gQCpjrNZcKJ8dA=="
         },
-        "@washingtonpost/wpds-accordion": {
-          "version": "0.17.0",
-          "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-accordion/-/wpds-accordion-0.17.0.tgz",
-          "integrity": "sha512-vbDzTQ/A1atTa8Rpzo6Vz5EOuheyiUVnk33lZfeo58aXY2eDys4N180VeZPFKOlMkJv7237W573deP8Zh1LFSA==",
-          "requires": {
-            "@radix-ui/react-accordion": "latest",
-            "@washingtonpost/wpds-assets": "*",
-            "@washingtonpost/wpds-icon": "0.17.0",
-            "@washingtonpost/wpds-theme": "0.17.0"
-          }
-        },
         "@washingtonpost/wpds-assets": {
           "version": "1.17.0",
           "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-assets/-/wpds-assets-1.17.0.tgz",
@@ -65064,33 +64996,6 @@
           "requires": {
             "react": "^16.0.1 || ^17.0.2",
             "react-dom": "^16.0.1 || ^17.0.2"
-          }
-        },
-        "@washingtonpost/wpds-icon": {
-          "version": "0.17.0",
-          "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-icon/-/wpds-icon-0.17.0.tgz",
-          "integrity": "sha512-nXEDWRoGt+v4n/9tVj41hfy0GXWX5+xsxT/31NN5upmRAiN114VCVA3YhADYuXSsfDsz/zsiCjvk6jtskPzXNA==",
-          "requires": {
-            "@washingtonpost/wpds-theme": "0.17.0",
-            "@washingtonpost/wpds-visually-hidden": "0.17.0",
-            "react": "^16.8.6 || ^17.0.2"
-          }
-        },
-        "@washingtonpost/wpds-theme": {
-          "version": "0.17.0",
-          "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-theme/-/wpds-theme-0.17.0.tgz",
-          "integrity": "sha512-zgwt7QpKS5kpmPIQ3hxhBXJ6SUN3weUYu+l+errrZOR5eJnIlRSnO+8eHWsVrgcFP8BEWA+kNFKVNjOe4zhhAg==",
-          "requires": {
-            "@stitches/react": "*"
-          }
-        },
-        "@washingtonpost/wpds-visually-hidden": {
-          "version": "0.17.0",
-          "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-visually-hidden/-/wpds-visually-hidden-0.17.0.tgz",
-          "integrity": "sha512-cfHPzLRFihRao+cleH7hlN7yid4mx9q/yPKwp8gPsxLbah2A5QNHtLAYacAvVvDaX0m7IWdnw1EdFXTDPgqfEQ==",
-          "requires": {
-            "@washingtonpost/wpds-theme": "0.17.0",
-            "react": "^16.8.6 || ^17.0.2"
           }
         },
         "ajv": {
@@ -65280,10 +65185,10 @@
       "requires": {
         "@radix-ui/react-focus-scope": "^1.0.0",
         "@washingtonpost/wpds-assets": "^1.16.0",
-        "@washingtonpost/wpds-button": "0.23.2",
-        "@washingtonpost/wpds-icon": "0.23.2",
-        "@washingtonpost/wpds-scrim": "0.23.2",
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-button": "0.24.0",
+        "@washingtonpost/wpds-icon": "0.24.0",
+        "@washingtonpost/wpds-scrim": "0.24.0",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "react-transition-group": "^4.4.5",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
@@ -65309,7 +65214,7 @@
     "@washingtonpost/wpds-error-message": {
       "version": "file:ui/error-message",
       "requires": {
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
       },
@@ -65325,7 +65230,7 @@
     "@washingtonpost/wpds-fieldset": {
       "version": "file:ui/fieldset",
       "requires": {
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
       },
@@ -65341,7 +65246,7 @@
     "@washingtonpost/wpds-helper-text": {
       "version": "file:ui/helper-text",
       "requires": {
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
       },
@@ -65357,8 +65262,8 @@
     "@washingtonpost/wpds-icon": {
       "version": "file:ui/icon",
       "requires": {
-        "@washingtonpost/wpds-theme": "0.23.2",
-        "@washingtonpost/wpds-visually-hidden": "0.23.2",
+        "@washingtonpost/wpds-theme": "0.24.0",
+        "@washingtonpost/wpds-visually-hidden": "0.24.0",
         "react": "^16.8.6 || ^17.0.2",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
@@ -65376,8 +65281,8 @@
       "version": "file:ui/input-label",
       "requires": {
         "@radix-ui/react-label": "^1.0.0",
-        "@washingtonpost/wpds-input-shared": "0.23.2",
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-input-shared": "0.24.0",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
       },
@@ -65457,8 +65362,8 @@
       "version": "file:ui/input-password",
       "requires": {
         "@washingtonpost/wpds-assets": "^1.16.0",
-        "@washingtonpost/wpds-icon": "0.23.2",
-        "@washingtonpost/wpds-input-text": "0.23.2",
+        "@washingtonpost/wpds-icon": "0.24.0",
+        "@washingtonpost/wpds-input-text": "0.24.0",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
       },
@@ -65483,7 +65388,7 @@
     "@washingtonpost/wpds-input-shared": {
       "version": "file:ui/input-shared",
       "requires": {
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
       },
@@ -65501,15 +65406,15 @@
       "requires": {
         "@radix-ui/react-label": "^1.0.0",
         "@washingtonpost/wpds-assets": "^1.16.0",
-        "@washingtonpost/wpds-box": "0.23.2",
-        "@washingtonpost/wpds-button": "0.23.2",
-        "@washingtonpost/wpds-error-message": "0.23.2",
-        "@washingtonpost/wpds-helper-text": "0.23.2",
-        "@washingtonpost/wpds-icon": "0.23.2",
-        "@washingtonpost/wpds-input-label": "0.23.2",
-        "@washingtonpost/wpds-input-shared": "0.23.2",
-        "@washingtonpost/wpds-theme": "0.23.2",
-        "@washingtonpost/wpds-visually-hidden": "0.23.2",
+        "@washingtonpost/wpds-box": "0.24.0",
+        "@washingtonpost/wpds-button": "0.24.0",
+        "@washingtonpost/wpds-error-message": "0.24.0",
+        "@washingtonpost/wpds-helper-text": "0.24.0",
+        "@washingtonpost/wpds-icon": "0.24.0",
+        "@washingtonpost/wpds-input-label": "0.24.0",
+        "@washingtonpost/wpds-input-shared": "0.24.0",
+        "@washingtonpost/wpds-theme": "0.24.0",
+        "@washingtonpost/wpds-visually-hidden": "0.24.0",
         "nanoid": "^3.3.2",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
@@ -65601,11 +65506,11 @@
     "@washingtonpost/wpds-input-textarea": {
       "version": "file:ui/input-textarea",
       "requires": {
-        "@washingtonpost/wpds-error-message": "0.23.2",
-        "@washingtonpost/wpds-helper-text": "0.23.2",
-        "@washingtonpost/wpds-input-label": "0.23.2",
-        "@washingtonpost/wpds-input-shared": "0.23.2",
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-error-message": "0.24.0",
+        "@washingtonpost/wpds-helper-text": "0.24.0",
+        "@washingtonpost/wpds-input-label": "0.24.0",
+        "@washingtonpost/wpds-input-shared": "0.24.0",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "react": "^16.8.6 || ^17.0.2",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
@@ -65622,7 +65527,7 @@
     "@washingtonpost/wpds-pagination-dots": {
       "version": "file:ui/pagination-dots",
       "requires": {
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
       },
@@ -65640,9 +65545,9 @@
       "requires": {
         "@radix-ui/react-popover": "^1.0.2",
         "@washingtonpost/wpds-assets": "*",
-        "@washingtonpost/wpds-button": "0.23.2",
-        "@washingtonpost/wpds-icon": "0.23.2",
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-button": "0.24.0",
+        "@washingtonpost/wpds-icon": "0.24.0",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
       },
@@ -65659,10 +65564,10 @@
       "version": "file:ui/radio-group",
       "requires": {
         "@radix-ui/react-radio-group": "^1.0.0",
-        "@washingtonpost/wpds-error-message": "0.23.2",
-        "@washingtonpost/wpds-fieldset": "0.23.2",
-        "@washingtonpost/wpds-input-label": "0.23.2",
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-error-message": "0.24.0",
+        "@washingtonpost/wpds-fieldset": "0.24.0",
+        "@washingtonpost/wpds-input-label": "0.24.0",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "nanoid": "^3.3.3",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
@@ -65821,7 +65726,7 @@
       "version": "file:ui/scrim",
       "requires": {
         "@radix-ui/react-dialog": "^1.0.0",
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "react-transition-group": "^4.4.5",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
@@ -65841,11 +65746,11 @@
         "@radix-ui/react-select": "^1.0.0",
         "@radix-ui/react-use-controllable-state": "^1.0.0",
         "@washingtonpost/wpds-assets": "*",
-        "@washingtonpost/wpds-divider": "0.23.2",
-        "@washingtonpost/wpds-icon": "0.23.2",
-        "@washingtonpost/wpds-input-label": "0.23.2",
-        "@washingtonpost/wpds-input-shared": "0.23.2",
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-divider": "0.24.0",
+        "@washingtonpost/wpds-icon": "0.24.0",
+        "@washingtonpost/wpds-input-label": "0.24.0",
+        "@washingtonpost/wpds-input-shared": "0.24.0",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
       },
@@ -65878,7 +65783,7 @@
       "version": "file:ui/tooltip",
       "requires": {
         "@radix-ui/react-tooltip": "^1.0.0",
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
       },
@@ -65894,35 +65799,35 @@
     "@washingtonpost/wpds-ui-kit": {
       "version": "file:ui/kit",
       "requires": {
-        "@washingtonpost/eslint-plugin-wpds": "0.23.2",
-        "@washingtonpost/wpds-accordion": "0.23.2",
-        "@washingtonpost/wpds-alert-banner": "0.23.2",
-        "@washingtonpost/wpds-app-bar": "0.23.2",
-        "@washingtonpost/wpds-avatar": "0.23.2",
-        "@washingtonpost/wpds-box": "0.23.2",
-        "@washingtonpost/wpds-button": "0.23.2",
-        "@washingtonpost/wpds-card": "0.23.2",
-        "@washingtonpost/wpds-checkbox": "0.23.2",
-        "@washingtonpost/wpds-container": "0.23.2",
-        "@washingtonpost/wpds-divider": "0.23.2",
-        "@washingtonpost/wpds-drawer": "0.23.2",
-        "@washingtonpost/wpds-error-message": "0.23.2",
-        "@washingtonpost/wpds-fieldset": "0.23.2",
-        "@washingtonpost/wpds-helper-text": "0.23.2",
-        "@washingtonpost/wpds-icon": "0.23.2",
-        "@washingtonpost/wpds-input-label": "0.23.2",
-        "@washingtonpost/wpds-input-password": "0.23.2",
-        "@washingtonpost/wpds-input-shared": "0.23.2",
-        "@washingtonpost/wpds-input-text": "0.23.2",
-        "@washingtonpost/wpds-input-textarea": "0.23.2",
-        "@washingtonpost/wpds-pagination-dots": "0.23.2",
-        "@washingtonpost/wpds-popover": "0.23.2",
-        "@washingtonpost/wpds-radio-group": "0.23.2",
-        "@washingtonpost/wpds-scrim": "0.23.2",
-        "@washingtonpost/wpds-select": "0.23.2",
-        "@washingtonpost/wpds-theme": "0.23.2",
-        "@washingtonpost/wpds-tooltip": "0.23.2",
-        "@washingtonpost/wpds-visually-hidden": "0.23.2",
+        "@washingtonpost/eslint-plugin-wpds": "0.24.0",
+        "@washingtonpost/wpds-accordion": "0.24.0",
+        "@washingtonpost/wpds-alert-banner": "0.24.0",
+        "@washingtonpost/wpds-app-bar": "0.24.0",
+        "@washingtonpost/wpds-avatar": "0.24.0",
+        "@washingtonpost/wpds-box": "0.24.0",
+        "@washingtonpost/wpds-button": "0.24.0",
+        "@washingtonpost/wpds-card": "0.24.0",
+        "@washingtonpost/wpds-checkbox": "0.24.0",
+        "@washingtonpost/wpds-container": "0.24.0",
+        "@washingtonpost/wpds-divider": "0.24.0",
+        "@washingtonpost/wpds-drawer": "0.24.0",
+        "@washingtonpost/wpds-error-message": "0.24.0",
+        "@washingtonpost/wpds-fieldset": "0.24.0",
+        "@washingtonpost/wpds-helper-text": "0.24.0",
+        "@washingtonpost/wpds-icon": "0.24.0",
+        "@washingtonpost/wpds-input-label": "0.24.0",
+        "@washingtonpost/wpds-input-password": "0.24.0",
+        "@washingtonpost/wpds-input-shared": "0.24.0",
+        "@washingtonpost/wpds-input-text": "0.24.0",
+        "@washingtonpost/wpds-input-textarea": "0.24.0",
+        "@washingtonpost/wpds-pagination-dots": "0.24.0",
+        "@washingtonpost/wpds-popover": "0.24.0",
+        "@washingtonpost/wpds-radio-group": "0.24.0",
+        "@washingtonpost/wpds-scrim": "0.24.0",
+        "@washingtonpost/wpds-select": "0.24.0",
+        "@washingtonpost/wpds-theme": "0.24.0",
+        "@washingtonpost/wpds-tooltip": "0.24.0",
+        "@washingtonpost/wpds-visually-hidden": "0.24.0",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
       },
@@ -65938,7 +65843,7 @@
     "@washingtonpost/wpds-visually-hidden": {
       "version": "file:ui/visually-hidden",
       "requires": {
-        "@washingtonpost/wpds-theme": "0.23.2",
+        "@washingtonpost/wpds-theme": "0.24.0",
         "react": "^16.8.6 || ^17.0.2",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
@@ -85474,84 +85379,6 @@
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
       "integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==",
       "dev": true
-    },
-    "@next/swc-android-arm-eabi": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.4.tgz",
-      "integrity": "sha512-cM42Cw6V4Bz/2+j/xIzO8nK/Q3Ly+VSlZJTa1vHzsocJRYz8KT6MrreXaci2++SIZCF1rVRCDgAg5PpqRibdIA==",
-      "optional": true
-    },
-    "@next/swc-android-arm64": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.4.tgz",
-      "integrity": "sha512-5jf0dTBjL+rabWjGj3eghpLUxCukRhBcEJgwLedewEA/LJk2HyqCvGIwj5rH+iwmq1llCWbOky2dO3pVljrapg==",
-      "optional": true
-    },
-    "@next/swc-darwin-arm64": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.4.tgz",
-      "integrity": "sha512-DqsSTd3FRjQUR6ao0E1e2OlOcrF5br+uegcEGPVonKYJpcr0MJrtYmPxd4v5T6UCJZ+XzydF7eQo5wdGvSZAyA==",
-      "optional": true
-    },
-    "@next/swc-darwin-x64": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.4.tgz",
-      "integrity": "sha512-PPF7tbWD4k0dJ2EcUSnOsaOJ5rhT3rlEt/3LhZUGiYNL8KvoqczFrETlUx0cUYaXe11dRA3F80Hpt727QIwByQ==",
-      "optional": true
-    },
-    "@next/swc-freebsd-x64": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.4.tgz",
-      "integrity": "sha512-KM9JXRXi/U2PUM928z7l4tnfQ9u8bTco/jb939pdFUHqc28V43Ohd31MmZD1QzEK4aFlMRaIBQOWQZh4D/E5lQ==",
-      "optional": true
-    },
-    "@next/swc-linux-arm-gnueabihf": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.4.tgz",
-      "integrity": "sha512-3zqD3pO+z5CZyxtKDTnOJ2XgFFRUBciOox6EWkoZvJfc9zcidNAQxuwonUeNts6Xbm8Wtm5YGIRC0x+12YH7kw==",
-      "optional": true
-    },
-    "@next/swc-linux-arm64-gnu": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.4.tgz",
-      "integrity": "sha512-kiX0vgJGMZVv+oo1QuObaYulXNvdH/IINmvdZnVzMO/jic/B8EEIGlZ8Bgvw8LCjH3zNVPO3mGrdMvnEEPEhKA==",
-      "optional": true
-    },
-    "@next/swc-linux-arm64-musl": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.4.tgz",
-      "integrity": "sha512-EETZPa1juczrKLWk5okoW2hv7D7WvonU+Cf2CgsSoxgsYbUCZ1voOpL4JZTOb6IbKMDo6ja+SbY0vzXZBUMvkQ==",
-      "optional": true
-    },
-    "@next/swc-linux-x64-gnu": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.4.tgz",
-      "integrity": "sha512-4csPbRbfZbuWOk3ATyWcvVFdD9/Rsdq5YHKvRuEni68OCLkfy4f+4I9OBpyK1SKJ00Cih16NJbHE+k+ljPPpag==",
-      "optional": true
-    },
-    "@next/swc-linux-x64-musl": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.4.tgz",
-      "integrity": "sha512-YeBmI+63Ro75SUiL/QXEVXQ19T++58aI/IINOyhpsRL1LKdyfK/35iilraZEFz9bLQrwy1LYAR5lK200A9Gjbg==",
-      "optional": true
-    },
-    "@next/swc-win32-arm64-msvc": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.4.tgz",
-      "integrity": "sha512-Sd0qFUJv8Tj0PukAYbCCDbmXcMkbIuhnTeHm9m4ZGjCf6kt7E/RMs55Pd3R5ePjOkN7dJEuxYBehawTR/aPDSQ==",
-      "optional": true
-    },
-    "@next/swc-win32-ia32-msvc": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.4.tgz",
-      "integrity": "sha512-rt/vv/vg/ZGGkrkKcuJ0LyliRdbskQU+91bje+PgoYmxTZf/tYs6IfbmgudBJk6gH3QnjHWbkphDdRQrseRefQ==",
-      "optional": true
-    },
-    "@next/swc-win32-x64-msvc": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.4.tgz",
-      "integrity": "sha512-DQ20JEfTBZAgF8QCjYfJhv2/279M6onxFjdG/+5B0Cyj00/EdBxiWb2eGGFgQhrBbNv/lsvzFbbi0Ptf8Vw/bg==",
-      "optional": true
     }
   }
 }


### PR DESCRIPTION
## What I did

The release is failing due to prettier updating the next.config.file and it not being able to merge the updates.