### PR TITLE
1.0 Release

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -28,5 +28,5 @@
       "registry": "https://registry.npmjs.org/"
     }
   },
-  "version": "0.25.1"
+  "version": "1.0.0-alpha.0"
 }


### PR DESCRIPTION
BREAKING CHANGE: Move to 1.0

## What I did

Manually bumping the Lerna version and including a breaking change commit message to push us to 1.0

SRED-39