### PR TITLE
fix: set accordion content font size to token size 100 to match designs

### DIFF
--- a/ui/accordion/src/AccordionContent.tsx
+++ b/ui/accordion/src/AccordionContent.tsx
@@ -30,6 +30,7 @@ const AnimatedContent = styled(AccordionPrimitive.Content, {
 const ContentContainer = styled("div", {
   paddingBottom: theme.space[150],
   paddingRight: theme.space[150],
+  fontSize: theme.fontSizes[100],
 });
 
 type AccordionContentVariants = WPDS.VariantProps<typeof AnimatedContent>;


### PR DESCRIPTION
## What I did
[SRED-74](https://arcpublishing.atlassian.net/browse/SRED-74)

Applied the correct font size of wpds token 100 to accordion content

[SRED-74]: https://arcpublishing.atlassian.net/browse/SRED-74?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ