### PR TITLE
fix: address a couple typos in the a11y build site docs

### DIFF
--- a/build.washingtonpost.com/docs/resources/accessibility/audio-and-video.mdx
+++ b/build.washingtonpost.com/docs/resources/accessibility/audio-and-video.mdx
@@ -120,6 +120,6 @@ Some users, including those with vestibular motion disorders, may have system se
 
 We have to write code that recognizes these system settings in order to adjust motion accordingly.
 
-To do this, we use the [prefers-reduced-motion CSS media feature](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) A good way to respond to user settings is [the prefers-color-scheme CSS media feature], as documented by MDN.
+To do this, we use the [prefers-reduced-motion CSS media feature](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion), as documented by MDN.
 
 Our [Tooltip component](/components/tooltip) uses `prefers-reduced-motion` to decide whether to include an animation when tooltip content is opened. If the user does not have reduced motion settings turned on, then the animation is used.

--- a/build.washingtonpost.com/docs/resources/accessibility/semantic-html.mdx
+++ b/build.washingtonpost.com/docs/resources/accessibility/semantic-html.mdx
@@ -141,7 +141,7 @@ You might use `aria-labelledby` to clarify for a screen reader the connection be
 </div>
 ```
 
-Note that the `aria-labelledby` is passed a string containing an element id or multiple ids separated by spaces. The text content of the elements with these ids is what will be read by the screen reader so that the user understands what each input field is for (i.e. "Billing Name" and "Billing Address."
+Note that the `aria-labelledby` is passed a string containing an element id or multiple ids separated by spaces. The text content of the elements with these ids is what will be read by the screen reader so that the user understands what each input field is for (in this case, "Billing Name" and "Billing Address").
 
 There is also an `aria-describedby` property meant to connect elements with relevant (but not essential information). This is not used as commonly, and `aria-labelledby` should be used regardless of whether a value for `aria-describedby` is also present on a given element.
 


### PR DESCRIPTION
## What I did
Fixed the typos listed in [SRED-107](https://arcpublishing.atlassian.net/jira/software/c/projects/SRED/boards/1185?modal=detail&selectedIssue=SRED-107)


[SRED-107]: https://arcpublishing.atlassian.net/browse/SRED-107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ