### PR TITLE
Lerna versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ main-publish:
 	npx lerna publish from-git --yes --no-git-reset --no-verify-access
 
 main-version:
-	npx lerna version --conventional-commits --conventional-graduate --yes --force-publish --create-release github
+	npx lerna version --conventional-commits --yes --force-publish --create-release github
 
 # create experimental release
 experimental-release:

--- a/package-lock.json
+++ b/package-lock.json
@@ -107,10 +107,10 @@
       }
     },
     "apps/vite-project": {
-      "version": "1.2.1",
+      "version": "1.3.0",
       "dependencies": {
-        "@washingtonpost/wpds-kitchen-sink": "1.2.1",
-        "@washingtonpost/wpds-ui-kit": "1.2.1",
+        "@washingtonpost/wpds-kitchen-sink": "1.3.0",
+        "@washingtonpost/wpds-ui-kit": "1.3.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -173,10 +173,10 @@
       }
     },
     "apps/vite-v2-project": {
-      "version": "1.2.1",
+      "version": "1.3.0",
       "dependencies": {
-        "@washingtonpost/wpds-kitchen-sink": "1.2.1",
-        "@washingtonpost/wpds-ui-kit": "1.2.1",
+        "@washingtonpost/wpds-kitchen-sink": "1.3.0",
+        "@washingtonpost/wpds-ui-kit": "1.3.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
       },
@@ -691,7 +691,7 @@
     },
     "build.washingtonpost.com": {
       "name": "@washingtonpost/wpds-docs",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/standalone": "^7.17.11",
@@ -709,8 +709,8 @@
         "@washingtonpost/tachyons-css": "latest",
         "@washingtonpost/wpds-accordion": "1.2.0",
         "@washingtonpost/wpds-assets": "^1.17.0",
-        "@washingtonpost/wpds-kitchen-sink": "1.2.1",
-        "@washingtonpost/wpds-ui-kit": "1.2.1",
+        "@washingtonpost/wpds-kitchen-sink": "1.3.0",
+        "@washingtonpost/wpds-ui-kit": "1.3.0",
         "fuse.js": "^6.6.2",
         "gray-matter": "^4.0.2",
         "lz-string": "^1.4.4",
@@ -45130,7 +45130,7 @@
     },
     "ui/checkbox": {
       "name": "@washingtonpost/wpds-checkbox",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.0.0",
@@ -46533,7 +46533,7 @@
     },
     "ui/kit": {
       "name": "@washingtonpost/wpds-ui-kit",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@washingtonpost/eslint-plugin-wpds": "1.2.0",
@@ -46545,7 +46545,7 @@
         "@washingtonpost/wpds-button": "1.2.0",
         "@washingtonpost/wpds-card": "1.2.0",
         "@washingtonpost/wpds-carousel": "1.2.0",
-        "@washingtonpost/wpds-checkbox": "1.2.1",
+        "@washingtonpost/wpds-checkbox": "1.3.0",
         "@washingtonpost/wpds-container": "1.2.0",
         "@washingtonpost/wpds-divider": "1.2.0",
         "@washingtonpost/wpds-drawer": "1.2.0",
@@ -46564,9 +46564,9 @@
         "@washingtonpost/wpds-scrim": "1.2.0",
         "@washingtonpost/wpds-select": "1.2.0",
         "@washingtonpost/wpds-switch": "1.2.0",
-        "@washingtonpost/wpds-tabs": "1.2.0",
+        "@washingtonpost/wpds-tabs": "1.3.0",
         "@washingtonpost/wpds-theme": "1.2.0",
-        "@washingtonpost/wpds-tooltip": "1.2.0",
+        "@washingtonpost/wpds-tooltip": "1.3.0",
         "@washingtonpost/wpds-visually-hidden": "1.2.0"
       },
       "devDependencies": {
@@ -46610,11 +46610,11 @@
     },
     "ui/kitchen-sink": {
       "name": "@washingtonpost/wpds-kitchen-sink",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@washingtonpost/wpds-assets": "latest",
-        "@washingtonpost/wpds-ui-kit": "1.2.1",
+        "@washingtonpost/wpds-ui-kit": "1.3.0",
         "nanoid": "^3.3.4"
       },
       "devDependencies": {
@@ -46854,7 +46854,7 @@
     },
     "ui/tabs": {
       "name": "@washingtonpost/wpds-tabs",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "^1.0.2",
@@ -46862,7 +46862,7 @@
         "@washingtonpost/wpds-assets": "^1.16.0",
         "@washingtonpost/wpds-icon": "1.1.0",
         "@washingtonpost/wpds-theme": "*",
-        "@washingtonpost/wpds-tooltip": "*",
+        "@washingtonpost/wpds-tooltip": "1.3.0",
         "react-transition-group": "^4.4.5"
       },
       "devDependencies": {
@@ -46927,7 +46927,7 @@
     },
     "ui/tooltip": {
       "name": "@washingtonpost/wpds-tooltip",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-tooltip": "^1.0.0",
@@ -59027,8 +59027,8 @@
         "@washingtonpost/tachyons-css": "latest",
         "@washingtonpost/wpds-accordion": "1.2.0",
         "@washingtonpost/wpds-assets": "^1.17.0",
-        "@washingtonpost/wpds-kitchen-sink": "1.2.1",
-        "@washingtonpost/wpds-ui-kit": "1.2.1",
+        "@washingtonpost/wpds-kitchen-sink": "1.3.0",
+        "@washingtonpost/wpds-ui-kit": "1.3.0",
         "babel-plugin-extract-react-types": "^0.1.14",
         "eslint": "8.6.0",
         "eslint-config-next": "^12.2.4",
@@ -59571,7 +59571,7 @@
       "version": "file:ui/kitchen-sink",
       "requires": {
         "@washingtonpost/wpds-assets": "latest",
-        "@washingtonpost/wpds-ui-kit": "1.2.1",
+        "@washingtonpost/wpds-ui-kit": "1.3.0",
         "nanoid": "^3.3.4",
         "tsup": "5.11.13",
         "typescript": "4.5.5"
@@ -59722,7 +59722,7 @@
         "@washingtonpost/wpds-assets": "^1.16.0",
         "@washingtonpost/wpds-icon": "1.1.0",
         "@washingtonpost/wpds-theme": "*",
-        "@washingtonpost/wpds-tooltip": "*",
+        "@washingtonpost/wpds-tooltip": "1.3.0",
         "react-transition-group": "^4.4.5",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
@@ -59786,7 +59786,7 @@
         "@washingtonpost/wpds-button": "1.2.0",
         "@washingtonpost/wpds-card": "1.2.0",
         "@washingtonpost/wpds-carousel": "1.2.0",
-        "@washingtonpost/wpds-checkbox": "1.2.1",
+        "@washingtonpost/wpds-checkbox": "1.3.0",
         "@washingtonpost/wpds-container": "1.2.0",
         "@washingtonpost/wpds-divider": "1.2.0",
         "@washingtonpost/wpds-drawer": "1.2.0",
@@ -59805,9 +59805,9 @@
         "@washingtonpost/wpds-scrim": "1.2.0",
         "@washingtonpost/wpds-select": "1.2.0",
         "@washingtonpost/wpds-switch": "1.2.0",
-        "@washingtonpost/wpds-tabs": "1.2.0",
+        "@washingtonpost/wpds-tabs": "1.3.0",
         "@washingtonpost/wpds-theme": "1.2.0",
-        "@washingtonpost/wpds-tooltip": "1.2.0",
+        "@washingtonpost/wpds-tooltip": "1.3.0",
         "@washingtonpost/wpds-visually-hidden": "1.2.0",
         "tsup": "5.11.13",
         "typescript": "4.5.5"
@@ -76826,8 +76826,8 @@
         "@types/react": "^18.0.27",
         "@types/react-dom": "^18.0.10",
         "@vitejs/plugin-react": "^3.1.0",
-        "@washingtonpost/wpds-kitchen-sink": "1.2.1",
-        "@washingtonpost/wpds-ui-kit": "1.2.1",
+        "@washingtonpost/wpds-kitchen-sink": "1.3.0",
+        "@washingtonpost/wpds-ui-kit": "1.3.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "vite": "^4.1.0"
@@ -76886,8 +76886,8 @@
         "@types/react": "^18.0.0",
         "@types/react-dom": "^18.0.0",
         "@vitejs/plugin-react": "^1.3.0",
-        "@washingtonpost/wpds-kitchen-sink": "1.2.1",
-        "@washingtonpost/wpds-ui-kit": "1.2.1",
+        "@washingtonpost/wpds-kitchen-sink": "1.3.0",
+        "@washingtonpost/wpds-ui-kit": "1.3.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "vite": "^2.9.15"


### PR DESCRIPTION
## What I did

This PR removes the `--conventional-graduate` flag from the versioning script. It appears that this flag directly conflicts with the `--force-publish` and is preventing all the packages from being versioned together.
