### PR TITLE
feat: upgrade wpds-assets to v1.18.0 in root and build.washingtonpost.com

### DIFF
--- a/build.washingtonpost.com/package.json
+++ b/build.washingtonpost.com/package.json
@@ -26,7 +26,7 @@
     "@washingtonpost/site-third-party-scripts": "latest",
     "@washingtonpost/tachyons-css": "latest",
     "@washingtonpost/wpds-accordion": "1.2.0",
-    "@washingtonpost/wpds-assets": "^1.17.0",
+    "@washingtonpost/wpds-assets": "^1.18.0",
     "@washingtonpost/wpds-kitchen-sink": "1.3.0",
     "@washingtonpost/wpds-ui-kit": "1.3.0",
     "fuse.js": "^6.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       ],
       "dependencies": {
         "@babel/standalone": "^7.17.11",
-        "@washingtonpost/wpds-assets": "^1.17.0",
+        "@washingtonpost/wpds-assets": "^1.18.0",
         "typescript": "4.5.5"
       },
       "devDependencies": {
@@ -708,7 +708,7 @@
         "@washingtonpost/site-third-party-scripts": "latest",
         "@washingtonpost/tachyons-css": "latest",
         "@washingtonpost/wpds-accordion": "1.2.0",
-        "@washingtonpost/wpds-assets": "^1.17.0",
+        "@washingtonpost/wpds-assets": "^1.18.0",
         "@washingtonpost/wpds-kitchen-sink": "1.3.0",
         "@washingtonpost/wpds-ui-kit": "1.3.0",
         "fuse.js": "^6.6.2",
@@ -17682,7 +17682,7 @@
       "link": true
     },
     "node_modules/@washingtonpost/wpds-assets": {
-      "version": "1.17.0",
+      "version": "1.18.0",
       "license": "ISC",
       "dependencies": {
         "react": "^16.0.1 || ^17.0.2",
@@ -44856,7 +44856,7 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-accordion": "latest",
-        "@washingtonpost/wpds-assets": "^1.17.0",
+        "@washingtonpost/wpds-assets": "^1.18.0",
         "@washingtonpost/wpds-icon": "1.2.0",
         "@washingtonpost/wpds-theme": "1.2.0"
       },
@@ -44866,7 +44866,7 @@
       },
       "peerDependencies": {
         "@radix-ui/react-accordion": "latest",
-        "@washingtonpost/wpds-assets": "^1.17.0",
+        "@washingtonpost/wpds-assets": "^1.18.0",
         "@washingtonpost/wpds-icon": "*",
         "@washingtonpost/wpds-theme": "*",
         "react": "^16.8.6 || ^17.0.2"
@@ -44956,7 +44956,7 @@
       "license": "MIT",
       "dependencies": {
         "@washingtonpost/wpds-app-bar": "1.2.0",
-        "@washingtonpost/wpds-assets": "^1.17.0",
+        "@washingtonpost/wpds-assets": "^1.18.0",
         "@washingtonpost/wpds-button": "1.2.0",
         "@washingtonpost/wpds-container": "1.2.0",
         "@washingtonpost/wpds-icon": "1.2.0",
@@ -44969,7 +44969,7 @@
       },
       "peerDependencies": {
         "@washingtonpost/wpds-app-bar": "*",
-        "@washingtonpost/wpds-assets": "^1.17.0",
+        "@washingtonpost/wpds-assets": "^1.18.0",
         "@washingtonpost/wpds-button": "*",
         "@washingtonpost/wpds-container": "*",
         "@washingtonpost/wpds-icon": "*",
@@ -45107,7 +45107,7 @@
       "dependencies": {
         "@radix-ui/react-slot": "^1.0.0",
         "@radix-ui/react-use-controllable-state": "^1.0.0",
-        "@washingtonpost/wpds-assets": "^1.17.0",
+        "@washingtonpost/wpds-assets": "^1.18.0",
         "@washingtonpost/wpds-button": "1.2.0",
         "@washingtonpost/wpds-icon": "1.2.0",
         "@washingtonpost/wpds-pagination-dots": "1.2.0",
@@ -45120,7 +45120,7 @@
         "typescript": "4.5.5"
       },
       "peerDependencies": {
-        "@washingtonpost/wpds-assets": "^1.17.0",
+        "@washingtonpost/wpds-assets": "^1.18.0",
         "@washingtonpost/wpds-button": "*",
         "@washingtonpost/wpds-icon": "*",
         "@washingtonpost/wpds-pagination-dots": "*",
@@ -45134,7 +45134,7 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.0.0",
-        "@washingtonpost/wpds-assets": "^1.17.0",
+        "@washingtonpost/wpds-assets": "^1.18.0",
         "@washingtonpost/wpds-icon": "1.2.0",
         "@washingtonpost/wpds-input-label": "1.2.0",
         "@washingtonpost/wpds-input-shared": "1.2.0",
@@ -45148,7 +45148,7 @@
       },
       "peerDependencies": {
         "@radix-ui/react-checkbox": "^1.0.0",
-        "@washingtonpost/wpds-assets": "^1.17.0",
+        "@washingtonpost/wpds-assets": "^1.18.0",
         "@washingtonpost/wpds-icon": "*",
         "@washingtonpost/wpds-input-label": "*",
         "@washingtonpost/wpds-input-shared": "*",
@@ -45285,7 +45285,7 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-focus-scope": "^1.0.0",
-        "@washingtonpost/wpds-assets": "^1.17.0",
+        "@washingtonpost/wpds-assets": "^1.18.0",
         "@washingtonpost/wpds-button": "1.2.0",
         "@washingtonpost/wpds-icon": "1.2.0",
         "@washingtonpost/wpds-scrim": "1.2.0",
@@ -45297,7 +45297,7 @@
         "typescript": "4.5.5"
       },
       "peerDependencies": {
-        "@washingtonpost/wpds-assets": "^1.17.0",
+        "@washingtonpost/wpds-assets": "^1.18.0",
         "@washingtonpost/wpds-button": "*",
         "@washingtonpost/wpds-icon": "*",
         "@washingtonpost/wpds-scrim": "*",
@@ -46366,7 +46366,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-assets": "^1.17.0",
+        "@washingtonpost/wpds-assets": "^1.18.0",
         "@washingtonpost/wpds-icon": "1.2.0",
         "@washingtonpost/wpds-input-text": "1.2.0"
       },
@@ -46375,7 +46375,7 @@
         "typescript": "4.5.5"
       },
       "peerDependencies": {
-        "@washingtonpost/wpds-assets": "^1.17.0",
+        "@washingtonpost/wpds-assets": "^1.18.0",
         "@washingtonpost/wpds-icon": "*",
         "@washingtonpost/wpds-input-text": "*",
         "react": "^16.8.6 || ^17.0.2"
@@ -46415,7 +46415,7 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-label": "^1.0.0",
-        "@washingtonpost/wpds-assets": "^1.17.0",
+        "@washingtonpost/wpds-assets": "^1.18.0",
         "@washingtonpost/wpds-box": "1.2.0",
         "@washingtonpost/wpds-button": "1.2.0",
         "@washingtonpost/wpds-error-message": "1.2.0",
@@ -46432,7 +46432,7 @@
         "typescript": "4.5.5"
       },
       "peerDependencies": {
-        "@washingtonpost/wpds-assets": "^1.17.0",
+        "@washingtonpost/wpds-assets": "^1.18.0",
         "@washingtonpost/wpds-box": "*",
         "@washingtonpost/wpds-button": "*",
         "@washingtonpost/wpds-error-message": "*",
@@ -46649,7 +46649,7 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-popover": "^1.0.2",
-        "@washingtonpost/wpds-assets": "^1.17.0",
+        "@washingtonpost/wpds-assets": "^1.18.0",
         "@washingtonpost/wpds-button": "1.2.0",
         "@washingtonpost/wpds-icon": "1.2.0",
         "@washingtonpost/wpds-theme": "1.2.0"
@@ -46659,7 +46659,7 @@
         "typescript": "4.5.5"
       },
       "peerDependencies": {
-        "@washingtonpost/wpds-theme": "^1.17.0",
+        "@washingtonpost/wpds-theme": "^1.18.0",
         "react": "^16.8.6 || ^17.0.2"
       }
     },
@@ -46811,7 +46811,7 @@
       "dependencies": {
         "@radix-ui/react-select": "^1.0.0",
         "@radix-ui/react-use-controllable-state": "^1.0.0",
-        "@washingtonpost/wpds-assets": "^1.17.0",
+        "@washingtonpost/wpds-assets": "^1.18.0",
         "@washingtonpost/wpds-divider": "1.2.0",
         "@washingtonpost/wpds-icon": "1.2.0",
         "@washingtonpost/wpds-input-label": "1.2.0",
@@ -46826,7 +46826,7 @@
       "peerDependencies": {
         "@radix-ui/react-select": "^1.0.0",
         "@radix-ui/react-use-controllable-state": "^1.0.0",
-        "@washingtonpost/wpds-assets": "^1.17.0",
+        "@washingtonpost/wpds-assets": "^1.18.0",
         "@washingtonpost/wpds-divider": "*",
         "@washingtonpost/wpds-icon": "*",
         "@washingtonpost/wpds-input-label": "*",
@@ -58741,7 +58741,7 @@
       "version": "file:ui/accordion",
       "requires": {
         "@radix-ui/react-accordion": "latest",
-        "@washingtonpost/wpds-assets": "^1.17.0",
+        "@washingtonpost/wpds-assets": "^1.18.0",
         "@washingtonpost/wpds-icon": "1.2.0",
         "@washingtonpost/wpds-theme": "1.2.0",
         "tsup": "5.11.13",
@@ -58807,7 +58807,7 @@
       "version": "file:ui/alert-banner",
       "requires": {
         "@washingtonpost/wpds-app-bar": "1.2.0",
-        "@washingtonpost/wpds-assets": "^1.17.0",
+        "@washingtonpost/wpds-assets": "^1.18.0",
         "@washingtonpost/wpds-button": "1.2.0",
         "@washingtonpost/wpds-container": "1.2.0",
         "@washingtonpost/wpds-icon": "1.2.0",
@@ -58836,7 +58836,7 @@
       }
     },
     "@washingtonpost/wpds-assets": {
-      "version": "1.17.0",
+      "version": "1.18.0",
       "requires": {
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
@@ -58902,7 +58902,7 @@
       "requires": {
         "@radix-ui/react-slot": "^1.0.0",
         "@radix-ui/react-use-controllable-state": "^1.0.0",
-        "@washingtonpost/wpds-assets": "^1.17.0",
+        "@washingtonpost/wpds-assets": "^1.18.0",
         "@washingtonpost/wpds-button": "1.2.0",
         "@washingtonpost/wpds-icon": "1.2.0",
         "@washingtonpost/wpds-pagination-dots": "1.2.0",
@@ -58917,7 +58917,7 @@
       "version": "file:ui/checkbox",
       "requires": {
         "@radix-ui/react-checkbox": "^1.0.0",
-        "@washingtonpost/wpds-assets": "^1.17.0",
+        "@washingtonpost/wpds-assets": "^1.18.0",
         "@washingtonpost/wpds-icon": "1.2.0",
         "@washingtonpost/wpds-input-label": "1.2.0",
         "@washingtonpost/wpds-input-shared": "1.2.0",
@@ -59026,7 +59026,7 @@
         "@washingtonpost/site-third-party-scripts": "latest",
         "@washingtonpost/tachyons-css": "latest",
         "@washingtonpost/wpds-accordion": "1.2.0",
-        "@washingtonpost/wpds-assets": "^1.17.0",
+        "@washingtonpost/wpds-assets": "^1.18.0",
         "@washingtonpost/wpds-kitchen-sink": "1.3.0",
         "@washingtonpost/wpds-ui-kit": "1.3.0",
         "babel-plugin-extract-react-types": "^0.1.14",
@@ -59382,7 +59382,7 @@
       "version": "file:ui/drawer",
       "requires": {
         "@radix-ui/react-focus-scope": "^1.0.0",
-        "@washingtonpost/wpds-assets": "^1.17.0",
+        "@washingtonpost/wpds-assets": "^1.18.0",
         "@washingtonpost/wpds-button": "1.2.0",
         "@washingtonpost/wpds-icon": "1.2.0",
         "@washingtonpost/wpds-scrim": "1.2.0",
@@ -59474,7 +59474,7 @@
     "@washingtonpost/wpds-input-password": {
       "version": "file:ui/input-password",
       "requires": {
-        "@washingtonpost/wpds-assets": "^1.17.0",
+        "@washingtonpost/wpds-assets": "^1.18.0",
         "@washingtonpost/wpds-icon": "1.2.0",
         "@washingtonpost/wpds-input-text": "1.2.0",
         "tsup": "5.11.13",
@@ -59502,7 +59502,7 @@
       "version": "file:ui/input-text",
       "requires": {
         "@radix-ui/react-label": "^1.0.0",
-        "@washingtonpost/wpds-assets": "^1.17.0",
+        "@washingtonpost/wpds-assets": "^1.18.0",
         "@washingtonpost/wpds-box": "1.2.0",
         "@washingtonpost/wpds-button": "1.2.0",
         "@washingtonpost/wpds-error-message": "1.2.0",
@@ -59589,7 +59589,7 @@
       "version": "file:ui/popover",
       "requires": {
         "@radix-ui/react-popover": "^1.0.2",
-        "@washingtonpost/wpds-assets": "^1.17.0",
+        "@washingtonpost/wpds-assets": "^1.18.0",
         "@washingtonpost/wpds-button": "1.2.0",
         "@washingtonpost/wpds-icon": "1.2.0",
         "@washingtonpost/wpds-theme": "1.2.0",
@@ -59694,7 +59694,7 @@
       "requires": {
         "@radix-ui/react-select": "^1.0.0",
         "@radix-ui/react-use-controllable-state": "^1.0.0",
-        "@washingtonpost/wpds-assets": "^1.17.0",
+        "@washingtonpost/wpds-assets": "^1.18.0",
         "@washingtonpost/wpds-divider": "1.2.0",
         "@washingtonpost/wpds-icon": "1.2.0",
         "@washingtonpost/wpds-input-label": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
   ],
   "dependencies": {
     "@babel/standalone": "^7.17.11",
-    "@washingtonpost/wpds-assets": "^1.17.0",
+    "@washingtonpost/wpds-assets": "^1.18.0",
     "typescript": "4.5.5"
   },
   "scripts": {
@@ -173,7 +173,7 @@
     "react-docgen-typescript": "^2.2.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "@washingtonpost/wpds-assets": "^1.17.0"
+    "@washingtonpost/wpds-assets": "^1.18.0"
   },
   "packageManager": "npm@8.11.0"
 }

--- a/ui/accordion/package.json
+++ b/ui/accordion/package.json
@@ -37,14 +37,14 @@
   },
   "peerDependencies": {
     "@radix-ui/react-accordion": "latest",
-    "@washingtonpost/wpds-assets": "^1.17.0",
+    "@washingtonpost/wpds-assets": "^1.18.0",
     "@washingtonpost/wpds-icon": "*",
     "@washingtonpost/wpds-theme": "*",
     "react": "^16.8.6 || ^17.0.2"
   },
   "dependencies": {
     "@radix-ui/react-accordion": "latest",
-    "@washingtonpost/wpds-assets": "^1.17.0",
+    "@washingtonpost/wpds-assets": "^1.18.0",
     "@washingtonpost/wpds-icon": "1.2.0",
     "@washingtonpost/wpds-theme": "1.2.0"
   },

--- a/ui/alert-banner/package.json
+++ b/ui/alert-banner/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "@washingtonpost/wpds-app-bar": "*",
-    "@washingtonpost/wpds-assets": "^1.17.0",
+    "@washingtonpost/wpds-assets": "^1.18.0",
     "@washingtonpost/wpds-button": "*",
     "@washingtonpost/wpds-container": "*",
     "@washingtonpost/wpds-icon": "*",
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@washingtonpost/wpds-app-bar": "1.2.0",
-    "@washingtonpost/wpds-assets": "^1.17.0",
+    "@washingtonpost/wpds-assets": "^1.18.0",
     "@washingtonpost/wpds-button": "1.2.0",
     "@washingtonpost/wpds-container": "1.2.0",
     "@washingtonpost/wpds-icon": "1.2.0",

--- a/ui/carousel/package.json
+++ b/ui/carousel/package.json
@@ -36,7 +36,7 @@
     "typescript": "4.5.5"
   },
   "peerDependencies": {
-    "@washingtonpost/wpds-assets": "^1.17.0",
+    "@washingtonpost/wpds-assets": "^1.18.0",
     "@washingtonpost/wpds-button": "*",
     "@washingtonpost/wpds-icon": "*",
     "@washingtonpost/wpds-pagination-dots": "*",
@@ -46,7 +46,7 @@
   "dependencies": {
     "@radix-ui/react-slot": "^1.0.0",
     "@radix-ui/react-use-controllable-state": "^1.0.0",
-    "@washingtonpost/wpds-assets": "^1.17.0",
+    "@washingtonpost/wpds-assets": "^1.18.0",
     "@washingtonpost/wpds-button": "1.2.0",
     "@washingtonpost/wpds-icon": "1.2.0",
     "@washingtonpost/wpds-pagination-dots": "1.2.0",

--- a/ui/checkbox/package.json
+++ b/ui/checkbox/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "@radix-ui/react-checkbox": "^1.0.0",
-    "@washingtonpost/wpds-assets": "^1.17.0",
+    "@washingtonpost/wpds-assets": "^1.18.0",
     "@washingtonpost/wpds-icon": "*",
     "@washingtonpost/wpds-input-label": "*",
     "@washingtonpost/wpds-input-shared": "*",
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.0.0",
-    "@washingtonpost/wpds-assets": "^1.17.0",
+    "@washingtonpost/wpds-assets": "^1.18.0",
     "@washingtonpost/wpds-icon": "1.2.0",
     "@washingtonpost/wpds-input-label": "1.2.0",
     "@washingtonpost/wpds-input-shared": "1.2.0",

--- a/ui/drawer/package.json
+++ b/ui/drawer/package.json
@@ -36,7 +36,7 @@
     "typescript": "4.5.5"
   },
   "peerDependencies": {
-    "@washingtonpost/wpds-assets": "^1.17.0",
+    "@washingtonpost/wpds-assets": "^1.18.0",
     "@washingtonpost/wpds-button": "*",
     "@washingtonpost/wpds-icon": "*",
     "@washingtonpost/wpds-scrim": "*",
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@radix-ui/react-focus-scope": "^1.0.0",
-    "@washingtonpost/wpds-assets": "^1.17.0",
+    "@washingtonpost/wpds-assets": "^1.18.0",
     "@washingtonpost/wpds-button": "1.2.0",
     "@washingtonpost/wpds-icon": "1.2.0",
     "@washingtonpost/wpds-scrim": "1.2.0",

--- a/ui/input-password/package.json
+++ b/ui/input-password/package.json
@@ -36,13 +36,13 @@
     "typescript": "4.5.5"
   },
   "peerDependencies": {
-    "@washingtonpost/wpds-assets": "^1.17.0",
+    "@washingtonpost/wpds-assets": "^1.18.0",
     "@washingtonpost/wpds-icon": "*",
     "@washingtonpost/wpds-input-text": "*",
     "react": "^16.8.6 || ^17.0.2"
   },
   "dependencies": {
-    "@washingtonpost/wpds-assets": "^1.17.0",
+    "@washingtonpost/wpds-assets": "^1.18.0",
     "@washingtonpost/wpds-icon": "1.2.0",
     "@washingtonpost/wpds-input-text": "1.2.0"
   },

--- a/ui/input-text/package.json
+++ b/ui/input-text/package.json
@@ -36,7 +36,7 @@
     "typescript": "4.5.5"
   },
   "peerDependencies": {
-    "@washingtonpost/wpds-assets": "^1.17.0",
+    "@washingtonpost/wpds-assets": "^1.18.0",
     "@washingtonpost/wpds-box": "*",
     "@washingtonpost/wpds-button": "*",
     "@washingtonpost/wpds-error-message": "*",
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@radix-ui/react-label": "^1.0.0",
-    "@washingtonpost/wpds-assets": "^1.17.0",
+    "@washingtonpost/wpds-assets": "^1.18.0",
     "@washingtonpost/wpds-box": "1.2.0",
     "@washingtonpost/wpds-button": "1.2.0",
     "@washingtonpost/wpds-error-message": "1.2.0",

--- a/ui/popover/package.json
+++ b/ui/popover/package.json
@@ -36,12 +36,12 @@
     "typescript": "4.5.5"
   },
   "peerDependencies": {
-    "@washingtonpost/wpds-theme": "^1.17.0",
+    "@washingtonpost/wpds-theme": "^1.18.0",
     "react": "^16.8.6 || ^17.0.2"
   },
   "dependencies": {
     "@radix-ui/react-popover": "^1.0.2",
-    "@washingtonpost/wpds-assets": "^1.17.0",
+    "@washingtonpost/wpds-assets": "^1.18.0",
     "@washingtonpost/wpds-button": "1.2.0",
     "@washingtonpost/wpds-icon": "1.2.0",
     "@washingtonpost/wpds-theme": "1.2.0"

--- a/ui/select/package.json
+++ b/ui/select/package.json
@@ -38,7 +38,7 @@
   "peerDependencies": {
     "@radix-ui/react-select": "^1.0.0",
     "@radix-ui/react-use-controllable-state": "^1.0.0",
-    "@washingtonpost/wpds-assets": "^1.17.0",
+    "@washingtonpost/wpds-assets": "^1.18.0",
     "@washingtonpost/wpds-divider": "*",
     "@washingtonpost/wpds-icon": "*",
     "@washingtonpost/wpds-input-label": "*",
@@ -49,7 +49,7 @@
   "dependencies": {
     "@radix-ui/react-select": "^1.0.0",
     "@radix-ui/react-use-controllable-state": "^1.0.0",
-    "@washingtonpost/wpds-assets": "^1.17.0",
+    "@washingtonpost/wpds-assets": "^1.18.0",
     "@washingtonpost/wpds-divider": "1.2.0",
     "@washingtonpost/wpds-icon": "1.2.0",
     "@washingtonpost/wpds-input-label": "1.2.0",


### PR DESCRIPTION
## What I did
Part of [SRED-100](https://arcpublishing.atlassian.net/jira/software/c/projects/SRED/boards/1185?modal=detail&selectedIssue=SRED-100): Upgrade to new wpds-assets version 1.18.0

[SRED-100]: https://arcpublishing.atlassian.net/browse/SRED-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ