### PR TITLE
chore: use exact version rather than wildcard in plop template

### DIFF
--- a/scripts/plopfile.js
+++ b/scripts/plopfile.js
@@ -54,6 +54,7 @@ module.exports = function (plop) {
         pattern: `"dependencies": {`,
         template: `"@washingtonpost/wpds-{{ dashCase componentName }}": "${lerna.version}",`,
       });
+
       actions.push({
         type: "append",
         path: "../ui/kit/package.json",

--- a/templates/component/package.json.hbs
+++ b/templates/component/package.json.hbs
@@ -40,6 +40,6 @@
 		"react": "^16.8.6 || ^17.0.2"
 	},
 	"dependencies": {
-		"@washingtonpost/wpds-theme": "*"
+		"@washingtonpost/wpds-theme": "{{ version }}"
 	}
 }


### PR DESCRIPTION
## What I did

Update template file to use specific version rather than asterisk in deps https://arcpublishing.atlassian.net/browse/SRED-146

<!--
  Explain the **motivation** for making this change. What existing problem does the pull request solve? Please be as detailed as possible.
-->
