### PR TITLE
chore: bump tachyons to 1.7.0

### DIFF
--- a/build.washingtonpost.com/package.json
+++ b/build.washingtonpost.com/package.json
@@ -24,7 +24,7 @@
     "@washingtonpost/site-favicons": "^0.1.0",
     "@washingtonpost/site-footer": "0.16.0",
     "@washingtonpost/site-third-party-scripts": "latest",
-    "@washingtonpost/tachyons-css": "latest",
+    "@washingtonpost/tachyons-css": "^1.7.0",
     "@washingtonpost/wpds-accordion": "1.4.0",
     "@washingtonpost/wpds-assets": "^1.18.0",
     "@washingtonpost/wpds-kitchen-sink": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -706,7 +706,7 @@
         "@washingtonpost/site-favicons": "^0.1.0",
         "@washingtonpost/site-footer": "0.16.0",
         "@washingtonpost/site-third-party-scripts": "latest",
-        "@washingtonpost/tachyons-css": "latest",
+        "@washingtonpost/tachyons-css": "^1.7.0",
         "@washingtonpost/wpds-accordion": "1.4.0",
         "@washingtonpost/wpds-assets": "^1.18.0",
         "@washingtonpost/wpds-kitchen-sink": "1.4.0",
@@ -1018,21 +1018,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "build.washingtonpost.com/node_modules/@washingtonpost/icon-tokens": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/icon-tokens/-/icon-tokens-1.9.1.tgz",
-      "integrity": "sha512-S9rF8EaWGBONuukT0Q16+CN17zVO7ovVH/o3bcWzNjkN/0oAXEuH6rPbeI4tqqE84tuCzaM85+g7bHLAHZpjFw=="
-    },
-    "build.washingtonpost.com/node_modules/@washingtonpost/motion-tokens": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/motion-tokens/-/motion-tokens-1.9.1.tgz",
-      "integrity": "sha512-gAnK5LjXTESAYvE4JcANkMsJfLqwQcxc8BBvgNpxu4iqKQ/PK4XhLeGqluMXaxoHZqqkdP9FvOT0gkWYRuIMmw=="
-    },
-    "build.washingtonpost.com/node_modules/@washingtonpost/shadow-tokens": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/shadow-tokens/-/shadow-tokens-1.9.1.tgz",
-      "integrity": "sha512-V6LEzXzFVcfWZLd7v3VU2wzymcBjX5nw6nLdJn0rN8Qn465wHqsTPitrKlcgp+Hq0JMtlPvBgXDOIZc+UIeR0w=="
-    },
     "build.washingtonpost.com/node_modules/@washingtonpost/site-footer": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@washingtonpost/site-footer/-/site-footer-0.16.0.tgz",
@@ -1061,11 +1046,6 @@
         "prop-types": "^15.7.2"
       }
     },
-    "build.washingtonpost.com/node_modules/@washingtonpost/spacing-tokens": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/spacing-tokens/-/spacing-tokens-1.9.1.tgz",
-      "integrity": "sha512-erhg0ofHhfQnbPcSr9R/eHDmdz3XhWzhoOpjFYGn/B2XIngg4N2Bd5WE/+2ZAMGScm+C2r87roYQRsJKb6a60A=="
-    },
     "build.washingtonpost.com/node_modules/@washingtonpost/tachyons-css": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@washingtonpost/tachyons-css/-/tachyons-css-1.6.0.tgz",
@@ -1088,11 +1068,6 @@
         "@washingtonpost/spacing-tokens": "latest",
         "@washingtonpost/typography-tokens": "latest"
       }
-    },
-    "build.washingtonpost.com/node_modules/@washingtonpost/typography-tokens": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/typography-tokens/-/typography-tokens-1.9.1.tgz",
-      "integrity": "sha512-Nq/KTKohoO35MEHe3HuQRpFR3KpC6qP7XyDw7HT4mV3AhkD3p99Zz/XjALXEk0/Cb/9WWpaZgeR7naWbsLOyEQ=="
     },
     "build.washingtonpost.com/node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -17643,9 +17618,25 @@
       "resolved": "https://registry.npmjs.org/@washingtonpost/front-end-utils/-/front-end-utils-0.4.4.tgz",
       "integrity": "sha512-2vY7uuMn3gjHDRi0G5SAy6HYm/GZ2FXVlwPlx+/cEH30WnieXKttJwe+M+mvX6cQDf8sg67WWPQJOZ7ta7yYoQ=="
     },
+    "node_modules/@washingtonpost/icon-tokens": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/icon-tokens/-/icon-tokens-1.9.1.tgz",
+      "integrity": "sha512-S9rF8EaWGBONuukT0Q16+CN17zVO7ovVH/o3bcWzNjkN/0oAXEuH6rPbeI4tqqE84tuCzaM85+g7bHLAHZpjFw=="
+    },
     "node_modules/@washingtonpost/logo-tokens": {
       "version": "1.9.1",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/@washingtonpost/logo-tokens/-/logo-tokens-1.9.1.tgz",
+      "integrity": "sha512-cUoVvJSy9CGXlnQpUhHQxejezk4g0t5/9VhWUourzh3biRP/JQ5I3vxu0UmzVSsxTQ58JUcn0+d78ZM4Ixly8g=="
+    },
+    "node_modules/@washingtonpost/motion-tokens": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/motion-tokens/-/motion-tokens-1.9.1.tgz",
+      "integrity": "sha512-gAnK5LjXTESAYvE4JcANkMsJfLqwQcxc8BBvgNpxu4iqKQ/PK4XhLeGqluMXaxoHZqqkdP9FvOT0gkWYRuIMmw=="
+    },
+    "node_modules/@washingtonpost/shadow-tokens": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/shadow-tokens/-/shadow-tokens-1.9.1.tgz",
+      "integrity": "sha512-V6LEzXzFVcfWZLd7v3VU2wzymcBjX5nw6nLdJn0rN8Qn465wHqsTPitrKlcgp+Hq0JMtlPvBgXDOIZc+UIeR0w=="
     },
     "node_modules/@washingtonpost/site-favicons": {
       "version": "0.1.0",
@@ -17675,6 +17666,16 @@
         "@washingtonpost/front-end-utils": "*",
         "react": "^16.0.1 || ^17.0.2"
       }
+    },
+    "node_modules/@washingtonpost/spacing-tokens": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/spacing-tokens/-/spacing-tokens-1.9.1.tgz",
+      "integrity": "sha512-erhg0ofHhfQnbPcSr9R/eHDmdz3XhWzhoOpjFYGn/B2XIngg4N2Bd5WE/+2ZAMGScm+C2r87roYQRsJKb6a60A=="
+    },
+    "node_modules/@washingtonpost/typography-tokens": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/typography-tokens/-/typography-tokens-1.9.1.tgz",
+      "integrity": "sha512-Nq/KTKohoO35MEHe3HuQRpFR3KpC6qP7XyDw7HT4mV3AhkD3p99Zz/XjALXEk0/Cb/9WWpaZgeR7naWbsLOyEQ=="
     },
     "node_modules/@washingtonpost/wpds-accordion": {
       "resolved": "ui/accordion",
@@ -58708,8 +58709,25 @@
       "resolved": "https://registry.npmjs.org/@washingtonpost/front-end-utils/-/front-end-utils-0.4.4.tgz",
       "integrity": "sha512-2vY7uuMn3gjHDRi0G5SAy6HYm/GZ2FXVlwPlx+/cEH30WnieXKttJwe+M+mvX6cQDf8sg67WWPQJOZ7ta7yYoQ=="
     },
+    "@washingtonpost/icon-tokens": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/icon-tokens/-/icon-tokens-1.9.1.tgz",
+      "integrity": "sha512-S9rF8EaWGBONuukT0Q16+CN17zVO7ovVH/o3bcWzNjkN/0oAXEuH6rPbeI4tqqE84tuCzaM85+g7bHLAHZpjFw=="
+    },
     "@washingtonpost/logo-tokens": {
-      "version": "1.9.1"
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/logo-tokens/-/logo-tokens-1.9.1.tgz",
+      "integrity": "sha512-cUoVvJSy9CGXlnQpUhHQxejezk4g0t5/9VhWUourzh3biRP/JQ5I3vxu0UmzVSsxTQ58JUcn0+d78ZM4Ixly8g=="
+    },
+    "@washingtonpost/motion-tokens": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/motion-tokens/-/motion-tokens-1.9.1.tgz",
+      "integrity": "sha512-gAnK5LjXTESAYvE4JcANkMsJfLqwQcxc8BBvgNpxu4iqKQ/PK4XhLeGqluMXaxoHZqqkdP9FvOT0gkWYRuIMmw=="
+    },
+    "@washingtonpost/shadow-tokens": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/shadow-tokens/-/shadow-tokens-1.9.1.tgz",
+      "integrity": "sha512-V6LEzXzFVcfWZLd7v3VU2wzymcBjX5nw6nLdJn0rN8Qn465wHqsTPitrKlcgp+Hq0JMtlPvBgXDOIZc+UIeR0w=="
     },
     "@washingtonpost/site-favicons": {
       "version": "0.1.0",
@@ -58724,6 +58742,16 @@
         "@washingtonpost/front-end-utils": "^0.4.4",
         "react": "^17.0.2"
       }
+    },
+    "@washingtonpost/spacing-tokens": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/spacing-tokens/-/spacing-tokens-1.9.1.tgz",
+      "integrity": "sha512-erhg0ofHhfQnbPcSr9R/eHDmdz3XhWzhoOpjFYGn/B2XIngg4N2Bd5WE/+2ZAMGScm+C2r87roYQRsJKb6a60A=="
+    },
+    "@washingtonpost/typography-tokens": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/typography-tokens/-/typography-tokens-1.9.1.tgz",
+      "integrity": "sha512-Nq/KTKohoO35MEHe3HuQRpFR3KpC6qP7XyDw7HT4mV3AhkD3p99Zz/XjALXEk0/Cb/9WWpaZgeR7naWbsLOyEQ=="
     },
     "@washingtonpost/wpds-accordion": {
       "version": "file:ui/accordion",
@@ -59012,7 +59040,7 @@
         "@washingtonpost/site-favicons": "^0.1.0",
         "@washingtonpost/site-footer": "0.16.0",
         "@washingtonpost/site-third-party-scripts": "latest",
-        "@washingtonpost/tachyons-css": "latest",
+        "@washingtonpost/tachyons-css": "^1.7.0",
         "@washingtonpost/wpds-accordion": "1.4.0",
         "@washingtonpost/wpds-assets": "^1.18.0",
         "@washingtonpost/wpds-kitchen-sink": "1.4.0",
@@ -59220,21 +59248,6 @@
             "eslint-visitor-keys": "^3.3.0"
           }
         },
-        "@washingtonpost/icon-tokens": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/@washingtonpost/icon-tokens/-/icon-tokens-1.9.1.tgz",
-          "integrity": "sha512-S9rF8EaWGBONuukT0Q16+CN17zVO7ovVH/o3bcWzNjkN/0oAXEuH6rPbeI4tqqE84tuCzaM85+g7bHLAHZpjFw=="
-        },
-        "@washingtonpost/motion-tokens": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/@washingtonpost/motion-tokens/-/motion-tokens-1.9.1.tgz",
-          "integrity": "sha512-gAnK5LjXTESAYvE4JcANkMsJfLqwQcxc8BBvgNpxu4iqKQ/PK4XhLeGqluMXaxoHZqqkdP9FvOT0gkWYRuIMmw=="
-        },
-        "@washingtonpost/shadow-tokens": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/@washingtonpost/shadow-tokens/-/shadow-tokens-1.9.1.tgz",
-          "integrity": "sha512-V6LEzXzFVcfWZLd7v3VU2wzymcBjX5nw6nLdJn0rN8Qn465wHqsTPitrKlcgp+Hq0JMtlPvBgXDOIZc+UIeR0w=="
-        },
         "@washingtonpost/site-footer": {
           "version": "0.16.0",
           "resolved": "https://registry.npmjs.org/@washingtonpost/site-footer/-/site-footer-0.16.0.tgz",
@@ -59247,14 +59260,8 @@
         "@washingtonpost/site-third-party-scripts": {
           "version": "0.3.3"
         },
-        "@washingtonpost/spacing-tokens": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/@washingtonpost/spacing-tokens/-/spacing-tokens-1.9.1.tgz",
-          "integrity": "sha512-erhg0ofHhfQnbPcSr9R/eHDmdz3XhWzhoOpjFYGn/B2XIngg4N2Bd5WE/+2ZAMGScm+C2r87roYQRsJKb6a60A=="
-        },
         "@washingtonpost/tachyons-css": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/@washingtonpost/tachyons-css/-/tachyons-css-1.6.0.tgz",
+          "version": "https://registry.npmjs.org/@washingtonpost/tachyons-css/-/tachyons-css-1.6.0.tgz",
           "integrity": "sha512-kUu7q8Y7FFSP+aSUMklp4Q+Va14H56JxVE+G4K9xts8hbf0IDYbVDkoatPaXjVPn3P33J3QjKFCEU5pGfPwo3A==",
           "requires": {
             "@washingtonpost/color-tokens": "latest",
@@ -59265,11 +59272,6 @@
             "@washingtonpost/spacing-tokens": "latest",
             "@washingtonpost/typography-tokens": "latest"
           }
-        },
-        "@washingtonpost/typography-tokens": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/@washingtonpost/typography-tokens/-/typography-tokens-1.9.1.tgz",
-          "integrity": "sha512-Nq/KTKohoO35MEHe3HuQRpFR3KpC6qP7XyDw7HT4mV3AhkD3p99Zz/XjALXEk0/Cb/9WWpaZgeR7naWbsLOyEQ=="
         },
         "ansi-styles": {
           "version": "4.3.0",


### PR DESCRIPTION
## What I did

https://github.com/washingtonpost/tachyons-css/releases/tag/v1.7.0

<!--
  Explain the **motivation** for making this change. What existing problem does the pull request solve? Please be as detailed as possible.
-->
