### PR TITLE
fix: improve color contrast on build.washingtonpost.com Sidebar for better accessibility

### DIFF
--- a/build.washingtonpost.com/components/Layout/Components/Sidebar.js
+++ b/build.washingtonpost.com/components/Layout/Components/Sidebar.js
@@ -96,7 +96,7 @@ const SideBarList = styled("ul", {
 });
 
 const ListItem = styled("li", {
-  color: "$accessible",
+  color: "$primary",
   cursor: "pointer",
   borderLeft: "4px solid",
   borderColor: "transparent",

--- a/build.washingtonpost.com/components/Markdown/Styling.js
+++ b/build.washingtonpost.com/components/Markdown/Styling.js
@@ -105,7 +105,7 @@ export const Change = styled("div", {
     type: {
       ComingSoon: {
         fontSize: "$075",
-        color: "$accessible",
+        color: "$primary",
         backgroundColor: "$gray400",
         borderColor: "$gray400",
       },

--- a/build.washingtonpost.com/components/logo.js
+++ b/build.washingtonpost.com/components/logo.js
@@ -18,7 +18,7 @@ const Container = styled("div", {
 });
 const Span = styled("span", {
   fontSize: "$125",
-  color: "$accessible",
+  color: "$primary",
   textDecoration: "none",
   width: "100%",
 });


### PR DESCRIPTION
## What I did
Used primary color instead of $accessible on the Sidebar of build.washingtonpost.com.

## Question
I'm also interested in updating the contrast on the little "coming soon" labels. Is that doable?

<img width="1792" alt="Screenshot 2023-04-20 at 11 39 50 AM" src="https://user-images.githubusercontent.com/38192823/233417378-85ee95e8-a315-46a5-862a-19250ca54c26.png">

<img width="1792" alt="Screenshot 2023-04-20 at 11 40 08 AM" src="https://user-images.githubusercontent.com/38192823/233417467-12263b10-b413-40c3-94e6-2736f8ccf481.png">
