### PR TITLE
Tabs visual bugs

### DIFF
--- a/ui/tabs/src/TabsList.tsx
+++ b/ui/tabs/src/TabsList.tsx
@@ -47,10 +47,19 @@ type TabsListProps = {
   React.ComponentProps<typeof StyledTabsList>;
 
 export const TabsList = React.forwardRef<HTMLDivElement, TabsListProps>(
-  ({ align = "left", children, ...props }: TabsListProps, ref) => {
+  (
+    { align = "left", density = "default", children, ...props }: TabsListProps,
+    ref
+  ) => {
     return (
       <StyledTabsList ref={ref} align={align} {...props}>
-        {children}
+        {React.Children.map(children, (child: React.ReactNode) => {
+          if (React.isValidElement(child)) {
+            return React.cloneElement(child, {
+              density: density,
+            });
+          }
+        })}
       </StyledTabsList>
     );
   }

--- a/ui/tabs/src/TabsList.tsx
+++ b/ui/tabs/src/TabsList.tsx
@@ -4,7 +4,6 @@ import * as TabsPrimitive from "@radix-ui/react-tabs";
 import type * as WPDS from "@washingtonpost/wpds-theme";
 
 import { styled, theme } from "@washingtonpost/wpds-theme";
-import { TabsContext } from "./context";
 
 const StyledTabsList = styled(TabsPrimitive.List, {
   flexShrink: 0,
@@ -49,39 +48,9 @@ type TabsListProps = {
 
 export const TabsList = React.forwardRef<HTMLDivElement, TabsListProps>(
   ({ align = "left", children, ...props }: TabsListProps, ref) => {
-    const [activeIndex, setActiveIndex] = React.useState(0);
-    const [previousRect, setPreviousRect] = React.useState<DOMRect | null>(
-      null
-    );
-
-    const { initialValue } = React.useContext(TabsContext);
-
-    React.useEffect(() => {
-      React.Children.map(children, (child: React.ReactNode, index: number) => {
-        if (React.isValidElement(child) && initialValue === child.props.value) {
-          setActiveIndex(index);
-        }
-      });
-    }, []);
-
     return (
-      <StyledTabsList ref={ref} align={align}>
-        {React.Children.map(
-          children,
-          (child: React.ReactNode, index: number) => {
-            if (React.isValidElement(child)) {
-              return React.cloneElement(child, {
-                active: activeIndex === index ? true : false,
-                onClick: () => {
-                  setActiveIndex(index);
-                },
-                previousRect,
-                setPreviousRect,
-                ...props,
-              });
-            }
-          }
-        )}
+      <StyledTabsList ref={ref} align={align} {...props}>
+        {children}
       </StyledTabsList>
     );
   }

--- a/ui/tabs/src/TabsRoot.test.tsx
+++ b/ui/tabs/src/TabsRoot.test.tsx
@@ -1,10 +1,51 @@
 import * as React from "react";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { TabsRoot } from "./TabsRoot";
+import { TabsTrigger } from "./TabsTrigger";
+import { TabsList } from "./TabsList";
 
 describe("TabsRoot Container", () => {
   test("renders visibly into the document", () => {
     render(<TabsRoot>Test</TabsRoot>);
     expect(screen.getByText("Test")).toBeVisible();
+  });
+
+  it("renders the tabs with the correct default value", () => {
+    render(
+      <TabsRoot defaultValue="A">
+        <TabsList>
+          <TabsTrigger value="A" />
+        </TabsList>
+      </TabsRoot>
+    );
+
+    expect(screen.getByRole("tab", { selected: true })).toBeInTheDocument();
+  });
+
+  it("renders the tabs with the correct value when the value prop is set", () => {
+    render(
+      <TabsRoot value="A">
+        <TabsList>
+          <TabsTrigger value="A" />
+        </TabsList>
+      </TabsRoot>
+    );
+
+    expect(screen.getByRole("tab", { selected: true })).toBeInTheDocument();
+  });
+
+  it("calls the onValueChange prop when the value changes", () => {
+    const onValueChange = jest.fn();
+    render(
+      <TabsRoot onValueChange={onValueChange} defaultValue="A">
+        <TabsList>
+          <TabsTrigger value="A">A</TabsTrigger>
+          <TabsTrigger value="B">B</TabsTrigger>
+        </TabsList>
+      </TabsRoot>
+    );
+    userEvent.click(screen.getByRole("tab", { selected: false }));
+    expect(onValueChange).toHaveBeenCalledWith("B");
   });
 });

--- a/ui/tabs/src/TabsRoot.tsx
+++ b/ui/tabs/src/TabsRoot.tsx
@@ -16,16 +16,37 @@ export type TabsRootProps = {
   css?: WPDS.CSS;
 } & React.ComponentPropsWithRef<typeof StyledTabsRoot>;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const TabsRoot = React.forwardRef<HTMLDivElement, TabsRootProps>(
   ({ children, ...props }: TabsRootProps, ref) => {
+    const [currentValue, setCurrentValue] = React.useState<string | undefined>(
+      props.defaultValue || props.value
+    );
+    const [previousRect, setPreviousRect] = React.useState<
+      DOMRect | undefined
+    >();
+    React.useEffect(() => {
+      if (props.value) {
+        setCurrentValue(props.value);
+      }
+    }, [props.value]);
     return (
       <TabsContext.Provider
         value={{
-          initialValue: props.defaultValue || props.value,
+          currentValue: currentValue,
+          previousRect: previousRect,
+          setPreviousRect: setPreviousRect,
         }}
       >
-        <StyledTabsRoot {...props} ref={ref}>
+        <StyledTabsRoot
+          {...props}
+          ref={ref}
+          onValueChange={(newValue) => {
+            setCurrentValue(newValue);
+            if (props.onValueChange) {
+              props.onValueChange(newValue);
+            }
+          }}
+        >
           {children}
         </StyledTabsRoot>
       </TabsContext.Provider>

--- a/ui/tabs/src/TabsTrigger.test.tsx
+++ b/ui/tabs/src/TabsTrigger.test.tsx
@@ -42,10 +42,10 @@ describe("TabsTrigger", () => {
   });
 
   test("sets previous rect", () => {
-    const Em = () => {
+    const Note = () => {
       const { previousRect } = React.useContext(TabsContext);
       if (previousRect) {
-        return <em role="note">{previousRect?.width}</em>;
+        return <span role="note">{previousRect.width}</span>;
       }
       return null;
     };
@@ -56,7 +56,7 @@ describe("TabsTrigger", () => {
           <TabsTrigger value="val1">Test</TabsTrigger>
           <TabsTrigger value="val2">Test2</TabsTrigger>
         </TabsList>
-        <Em />
+        <Note />
       </TabsRoot>
     );
     userEvent.click(screen.getByRole("tab", { selected: false }));

--- a/ui/tabs/src/TabsTrigger.test.tsx
+++ b/ui/tabs/src/TabsTrigger.test.tsx
@@ -3,7 +3,11 @@ import { render, screen } from "@testing-library/react";
 import { TabsRoot } from "./TabsRoot";
 import { TabsList } from "./TabsList";
 import { TabsTrigger } from "./TabsTrigger";
+import { TabsContext } from "./context";
 import { userEvent } from "@storybook/testing-library";
+import { config } from "react-transition-group";
+
+config.disabled = true;
 
 describe("TabsTrigger", () => {
   test("renders visibly into the document", () => {
@@ -35,5 +39,27 @@ describe("TabsTrigger", () => {
     userEvent.click(trigger2);
     expect(trigger2).toHaveAttribute("data-state", "active");
     expect(trigger2).toHaveStyle("borderBottom: 1px solid ##111111");
+  });
+
+  test("sets previous rect", () => {
+    const Em = () => {
+      const { previousRect } = React.useContext(TabsContext);
+      if (previousRect) {
+        return <em role="note">{previousRect?.width}</em>;
+      }
+      return null;
+    };
+
+    render(
+      <TabsRoot defaultValue="val1">
+        <TabsList>
+          <TabsTrigger value="val1">Test</TabsTrigger>
+          <TabsTrigger value="val2">Test2</TabsTrigger>
+        </TabsList>
+        <Em />
+      </TabsRoot>
+    );
+    userEvent.click(screen.getByRole("tab", { selected: false }));
+    expect(screen.getByRole("note")).toBeInTheDocument();
   });
 });

--- a/ui/tabs/src/TabsTriggerContent.test.tsx
+++ b/ui/tabs/src/TabsTriggerContent.test.tsx
@@ -41,4 +41,17 @@ describe("TabsTriggerContent", () => {
 
     expect(screen.getByTestId("tabs-tooltip-trigger")).toBeVisible();
   });
+
+  test("renders non text nodes", () => {
+    render(
+      <TabsRoot>
+        <TabsList>
+          <TabsTriggerContent>
+            <div>Test</div>
+          </TabsTriggerContent>
+        </TabsList>
+      </TabsRoot>
+    );
+    expect(screen.getByText("Test")).toBeVisible();
+  });
 });

--- a/ui/tabs/src/TabsTriggerContent.tsx
+++ b/ui/tabs/src/TabsTriggerContent.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { styled } from "@washingtonpost/wpds-theme";
+import { styled, theme } from "@washingtonpost/wpds-theme";
 import type * as WPDS from "@washingtonpost/wpds-theme";
 import { Tooltip } from "@washingtonpost/wpds-tooltip";
 
@@ -12,8 +12,19 @@ const StyledContainer = styled("div", {
 });
 
 const StyledTabText = styled("div", {
-  flex: "1 0 auto",
-  maxWidth: "24ch", // ch value is based on the width of the font 0. This is a rough approximation
+  display: "inline-flex",
+  flexDirection: "column",
+  maxWidth: "14rem", // use rems, as ch value shifts when text is active bold
+  "&::after": {
+    content: "attr(data-text)",
+    fontWeight: theme.fontWeights.bold,
+    height: 0,
+    visibility: "hidden",
+  },
+});
+
+const Truncate = styled("span", {
+  maxWidth: "100%",
   overflow: "hidden",
   textOverflow: "ellipsis",
   whiteSpace: "nowrap",
@@ -30,29 +41,29 @@ export type TabsTriggerContentProps = {
 } & React.ComponentPropsWithoutRef<typeof StyledContainer>;
 
 export const TabsTriggerContent = ({ children }: TabsTriggerContentProps) => {
-  const internalRef = React.useRef<HTMLDivElement | null>(null);
+  const internalRef = React.useRef<HTMLSpanElement | null>(null);
 
   const [truncated, setTruncated] = React.useState(false);
-
-  const childrenArray = React.Children.toArray(children);
-  const hasMoreThanOneChild = childrenArray.length > 1;
-
   React.useEffect(() => {
     const element = internalRef?.current;
     setTruncated(isTruncated(element));
   }, []);
 
-  // the parent container is flex, but the StyledTabText component cannot be set to
-  // flex since we want to show the ellipsis. For this reason, we need to split the
-  // children components
-  const content = hasMoreThanOneChild ? (
-    <>
-      {childrenArray[0]}
-      <StyledTabText ref={internalRef}>{childrenArray[1]}</StyledTabText>
-    </>
-  ) : (
-    <StyledTabText ref={internalRef}>{children}</StyledTabText>
-  );
+  const childrenArray = React.Children.toArray(children);
+
+  // the StyledTabText component is set to inline flex to include bolded spacer text
+  // that prevents shifting. Additional Truncate is needed to show the ellipsis. Other
+  // components like icons are simply returned
+  const content = childrenArray.map((child) => {
+    if (typeof child === "string") {
+      return (
+        <StyledTabText data-text={child} key={child}>
+          <Truncate ref={internalRef}>{child}</Truncate>
+        </StyledTabText>
+      );
+    }
+    return child;
+  });
 
   return (
     <>

--- a/ui/tabs/src/context.ts
+++ b/ui/tabs/src/context.ts
@@ -1,12 +1,16 @@
 import * as React from "react";
 
 interface TabsContextInterface {
-  initialValue?: string;
+  currentValue: string | undefined;
+  previousRect: DOMRect | undefined;
+  setPreviousRect: (rect: DOMRect) => void;
 }
 
 const defaultState = {
-  initialValue: "",
+  currentValue: undefined,
+  previousRect: undefined,
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  setPreviousRect: () => {},
 };
-
 export const TabsContext =
   React.createContext<TabsContextInterface>(defaultState);

--- a/ui/tabs/src/play.stories.tsx
+++ b/ui/tabs/src/play.stories.tsx
@@ -47,6 +47,12 @@ const StyledLabel = styled("div", {
   color: theme.colors.primary,
 });
 
+const StyledStack = styled("div", {
+  display: "flex",
+  flexDirection: "column",
+  gap: theme.space["100"],
+});
+
 const StyledContent = styled(Tabs.Content, {
   minHeight: "50px",
   paddingTop: "20px",
@@ -151,6 +157,44 @@ Center.args = {
   align: "center",
   density: "compact",
 };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const TemplateDensity: ComponentStory<any> = () => {
+  return (
+    <StyledStack>
+      <StyledLabel>Outline for viewing alignment purposes only</StyledLabel>
+      <StyledTabs>
+        <Tabs.Root defaultValue="tab1">
+          <Tabs.List aria-label="Countries' information" density="compact">
+            <Tabs.Trigger value="tab1"> France </Tabs.Trigger>
+            <Tabs.Trigger value="tab2">Brazil</Tabs.Trigger>
+            <Tabs.Trigger value="tab3">Vietnam</Tabs.Trigger>
+          </Tabs.List>
+        </Tabs.Root>
+      </StyledTabs>
+      <StyledTabs>
+        <Tabs.Root defaultValue="tab1">
+          <Tabs.List aria-label="Countries' information" density="default">
+            <Tabs.Trigger value="tab1">France</Tabs.Trigger>
+            <Tabs.Trigger value="tab2">Brazil</Tabs.Trigger>
+            <Tabs.Trigger value="tab3">Vietnam</Tabs.Trigger>
+          </Tabs.List>
+        </Tabs.Root>
+      </StyledTabs>
+      <StyledTabs>
+        <Tabs.Root defaultValue="tab1">
+          <Tabs.List aria-label="Countries' information" density="loose">
+            <Tabs.Trigger value="tab1"> France </Tabs.Trigger>
+            <Tabs.Trigger value="tab2">Brazil</Tabs.Trigger>
+            <Tabs.Trigger value="tab3">Vietnam</Tabs.Trigger>
+          </Tabs.List>
+        </Tabs.Root>
+      </StyledTabs>
+    </StyledStack>
+  );
+};
+
+export const Density = TemplateDensity.bind({});
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const TemplateControlled: ComponentStory<any> = (args) => {

--- a/ui/tabs/src/play.stories.tsx
+++ b/ui/tabs/src/play.stories.tsx
@@ -36,6 +36,7 @@ export default {
 } as ComponentMeta<typeof Tabs.Root>;
 
 const StyledTabs = styled("div", {
+  backgroundColor: theme.colors.secondary,
   width: "500px",
   border: `1px dashed ${theme.colors.primary}`,
   padding: "10px",
@@ -172,10 +173,10 @@ const TemplateControlled: ComponentStory<any> = (args) => {
             align={align}
           >
             <Tabs.Trigger value="tab1">
+              France
               <Icon label="trigger icon">
                 <Info />
               </Icon>
-              France
             </Tabs.Trigger>
             <Tabs.Trigger value="tab2">Kenya</Tabs.Trigger>
             <Tabs.Trigger value="tab3">Austria</Tabs.Trigger>
@@ -185,6 +186,19 @@ const TemplateControlled: ComponentStory<any> = (args) => {
           <StyledContent value="tab3">Austria is here 🇦🇹</StyledContent>
         </Tabs.Root>
       </StyledTabs>
+      <div style={{ padding: "1rem" }}>
+        <label style={{ display: "block" }}>Change selected tab</label>
+        <select
+          onChange={(e) => {
+            setValue(e.target.value);
+          }}
+          value={value}
+        >
+          <option value="tab1">Tab1</option>
+          <option value="tab2">Tab2</option>
+          <option value="tab3">Tab3</option>
+        </select>
+      </div>
     </>
   );
 };


### PR DESCRIPTION
## What I did

This PR fixes the horizontal shift in Tabs labels when the active tab changes and its text is bolded.

In addition: 
* fixes a bug where the initial tab change would not trigger an indicator animation when the component was uncontrolled. 
* All props are now passed through in the `TabsList` allowing for appearance customization  

SRED-231