### PR TITLE
chore: upgrade wpds-assets to 1.19.1 in build.washingtonpost.com package file

### DIFF
--- a/build.washingtonpost.com/package.json
+++ b/build.washingtonpost.com/package.json
@@ -24,7 +24,7 @@
     "@washingtonpost/site-favicons": "^0.1.3",
     "@washingtonpost/tachyons-css": "^1.7.0",
     "@washingtonpost/wpds-accordion": "1.5.2",
-    "@washingtonpost/wpds-assets": "^1.19.0",
+    "@washingtonpost/wpds-assets": "^1.19.1",
     "@washingtonpost/wpds-kitchen-sink": "1.5.2",
     "@washingtonpost/wpds-ui-kit": "1.5.2",
     "fuse.js": "^6.6.2",

--- a/build.washingtonpost.com/package.json
+++ b/build.washingtonpost.com/package.json
@@ -24,7 +24,7 @@
     "@washingtonpost/site-favicons": "^0.1.3",
     "@washingtonpost/tachyons-css": "^1.7.0",
     "@washingtonpost/wpds-accordion": "1.5.2",
-    "@washingtonpost/wpds-assets": "^1.19.1",
+    "@washingtonpost/wpds-assets": "^1.19.2",
     "@washingtonpost/wpds-kitchen-sink": "1.5.2",
     "@washingtonpost/wpds-ui-kit": "1.5.2",
     "fuse.js": "^6.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -709,7 +709,7 @@
         "@washingtonpost/site-favicons": "^0.1.3",
         "@washingtonpost/tachyons-css": "^1.7.0",
         "@washingtonpost/wpds-accordion": "1.5.2",
-        "@washingtonpost/wpds-assets": "^1.19.0",
+        "@washingtonpost/wpds-assets": "^1.19.1",
         "@washingtonpost/wpds-kitchen-sink": "1.5.2",
         "@washingtonpost/wpds-ui-kit": "1.5.2",
         "fuse.js": "^6.6.2",
@@ -1043,9 +1043,9 @@
       }
     },
     "build.washingtonpost.com/node_modules/@washingtonpost/wpds-assets": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-assets/-/wpds-assets-1.19.0.tgz",
-      "integrity": "sha512-C5J5iQdfHBJCKrdnvbjIPTndFez6/Zn9IJLHc/jrC7wQUJsaZbcVxYBgrhOyXw2r+6BO6gso0zINO6iopLzo0A==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-assets/-/wpds-assets-1.19.1.tgz",
+      "integrity": "sha512-Ad9MahGaiPMMFJ7+ny4uk71Vpusg4ScPDeDP8u3R1CsWfOj4mZ73JEusKbQSZitemJzB48RVBnk52PAHkRIRZg==",
       "dependencies": {
         "react": "^16.0.1 || ^17.0.2",
         "react-dom": "^16.0.1 || ^17.0.2"
@@ -62344,7 +62344,7 @@
         "@washingtonpost/site-favicons": "^0.1.3",
         "@washingtonpost/tachyons-css": "^1.7.0",
         "@washingtonpost/wpds-accordion": "1.5.2",
-        "@washingtonpost/wpds-assets": "^1.19.0",
+        "@washingtonpost/wpds-assets": "1.19.1",
         "@washingtonpost/wpds-kitchen-sink": "1.5.2",
         "@washingtonpost/wpds-ui-kit": "1.5.2",
         "babel-plugin-extract-react-types": "^0.1.14",
@@ -62564,9 +62564,9 @@
           }
         },
         "@washingtonpost/wpds-assets": {
-          "version": "1.19.0",
-          "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-assets/-/wpds-assets-1.19.0.tgz",
-          "integrity": "sha512-C5J5iQdfHBJCKrdnvbjIPTndFez6/Zn9IJLHc/jrC7wQUJsaZbcVxYBgrhOyXw2r+6BO6gso0zINO6iopLzo0A==",
+          "version": "1.19.1",
+          "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-assets/-/wpds-assets-1.19.1.tgz",
+          "integrity": "sha512-Ad9MahGaiPMMFJ7+ny4uk71Vpusg4ScPDeDP8u3R1CsWfOj4mZ73JEusKbQSZitemJzB48RVBnk52PAHkRIRZg==",
           "requires": {
             "react": "^16.0.1 || ^17.0.2",
             "react-dom": "^16.0.1 || ^17.0.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       ],
       "dependencies": {
         "@babel/standalone": "^7.17.11",
-        "@washingtonpost/wpds-assets": "^1.18.0",
+        "@washingtonpost/wpds-assets": "^1.19.2",
         "typescript": "4.5.5"
       },
       "devDependencies": {
@@ -709,7 +709,7 @@
         "@washingtonpost/site-favicons": "^0.1.3",
         "@washingtonpost/tachyons-css": "^1.7.0",
         "@washingtonpost/wpds-accordion": "1.5.2",
-        "@washingtonpost/wpds-assets": "^1.19.1",
+        "@washingtonpost/wpds-assets": "^1.19.2",
         "@washingtonpost/wpds-kitchen-sink": "1.5.2",
         "@washingtonpost/wpds-ui-kit": "1.5.2",
         "fuse.js": "^6.6.2",
@@ -1043,8 +1043,8 @@
       }
     },
     "build.washingtonpost.com/node_modules/@washingtonpost/wpds-assets": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-assets/-/wpds-assets-1.19.1.tgz",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-assets/-/wpds-assets-1.19.2.tgz",
       "integrity": "sha512-Ad9MahGaiPMMFJ7+ny4uk71Vpusg4ScPDeDP8u3R1CsWfOj4mZ73JEusKbQSZitemJzB48RVBnk52PAHkRIRZg==",
       "dependencies": {
         "react": "^16.0.1 || ^17.0.2",
@@ -17744,8 +17744,9 @@
       "link": true
     },
     "node_modules/@washingtonpost/wpds-assets": {
-      "version": "1.18.0",
-      "license": "ISC",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-assets/-/wpds-assets-1.19.2.tgz",
+      "integrity": "sha512-+1dfcnQRxkGXtZB+5wtGT97JqqgJ8tie+Pv05ujaV06pXTdNSorkV403EpFQEzinT0sTBEslI8QGJW8uK9OHRw==",
       "dependencies": {
         "react": "^16.0.1 || ^17.0.2",
         "react-dom": "^16.0.1 || ^17.0.2"
@@ -38883,7 +38884,7 @@
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
+        "es-abstract": "^1.19.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -38896,7 +38897,7 @@
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
+        "es-abstract": "^1.19.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -38964,7 +38965,7 @@
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
+        "es-abstract": "^1.19.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -44469,7 +44470,7 @@
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1",
+        "es-abstract": "^1.19.2",
         "get-intrinsic": "^1.1.1",
         "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
@@ -44519,7 +44520,7 @@
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
+        "es-abstract": "^1.19.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -48089,7 +48090,7 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-accordion": "latest",
-        "@washingtonpost/wpds-assets": "^1.18.0",
+        "@washingtonpost/wpds-assets": "^1.19.2",
         "@washingtonpost/wpds-icon": "1.5.2",
         "@washingtonpost/wpds-theme": "1.5.2"
       },
@@ -48099,7 +48100,7 @@
       },
       "peerDependencies": {
         "@radix-ui/react-accordion": "latest",
-        "@washingtonpost/wpds-assets": "^1.18.0",
+        "@washingtonpost/wpds-assets": "^1.19.2",
         "@washingtonpost/wpds-icon": "*",
         "@washingtonpost/wpds-theme": "*",
         "react": "^16.8.6 || ^17.0.2"
@@ -48189,7 +48190,7 @@
       "license": "MIT",
       "dependencies": {
         "@washingtonpost/wpds-app-bar": "1.5.2",
-        "@washingtonpost/wpds-assets": "^1.18.0",
+        "@washingtonpost/wpds-assets": "^1.19.2",
         "@washingtonpost/wpds-button": "1.5.2",
         "@washingtonpost/wpds-container": "1.5.2",
         "@washingtonpost/wpds-icon": "1.5.2",
@@ -48202,7 +48203,7 @@
       },
       "peerDependencies": {
         "@washingtonpost/wpds-app-bar": "*",
-        "@washingtonpost/wpds-assets": "^1.18.0",
+        "@washingtonpost/wpds-assets": "^1.19.2",
         "@washingtonpost/wpds-button": "*",
         "@washingtonpost/wpds-container": "*",
         "@washingtonpost/wpds-icon": "*",
@@ -48340,7 +48341,7 @@
       "dependencies": {
         "@radix-ui/react-slot": "^1.0.0",
         "@radix-ui/react-use-controllable-state": "^1.0.0",
-        "@washingtonpost/wpds-assets": "^1.18.0",
+        "@washingtonpost/wpds-assets": "^1.19.2",
         "@washingtonpost/wpds-button": "1.5.2",
         "@washingtonpost/wpds-icon": "1.5.2",
         "@washingtonpost/wpds-pagination-dots": "1.5.2",
@@ -48353,7 +48354,7 @@
         "typescript": "4.5.5"
       },
       "peerDependencies": {
-        "@washingtonpost/wpds-assets": "^1.18.0",
+        "@washingtonpost/wpds-assets": "^1.19.2",
         "@washingtonpost/wpds-button": "*",
         "@washingtonpost/wpds-icon": "*",
         "@washingtonpost/wpds-pagination-dots": "*",
@@ -48367,7 +48368,7 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.0.0",
-        "@washingtonpost/wpds-assets": "^1.18.0",
+        "@washingtonpost/wpds-assets": "^1.19.2",
         "@washingtonpost/wpds-icon": "1.5.2",
         "@washingtonpost/wpds-input-label": "1.5.2",
         "@washingtonpost/wpds-input-shared": "1.5.2",
@@ -48381,7 +48382,7 @@
       },
       "peerDependencies": {
         "@radix-ui/react-checkbox": "^1.0.0",
-        "@washingtonpost/wpds-assets": "^1.18.0",
+        "@washingtonpost/wpds-assets": "^1.19.2",
         "@washingtonpost/wpds-icon": "*",
         "@washingtonpost/wpds-input-label": "*",
         "@washingtonpost/wpds-input-shared": "*",
@@ -48518,7 +48519,7 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-focus-scope": "^1.0.0",
-        "@washingtonpost/wpds-assets": "^1.18.0",
+        "@washingtonpost/wpds-assets": "^1.19.2",
         "@washingtonpost/wpds-button": "1.5.2",
         "@washingtonpost/wpds-icon": "1.5.2",
         "@washingtonpost/wpds-scrim": "1.5.2",
@@ -48530,7 +48531,7 @@
         "typescript": "4.5.5"
       },
       "peerDependencies": {
-        "@washingtonpost/wpds-assets": "^1.18.0",
+        "@washingtonpost/wpds-assets": "^1.19.2",
         "@washingtonpost/wpds-button": "*",
         "@washingtonpost/wpds-icon": "*",
         "@washingtonpost/wpds-scrim": "*",
@@ -49599,7 +49600,7 @@
       "version": "1.5.2",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-assets": "^1.18.0",
+        "@washingtonpost/wpds-assets": "^1.19.2",
         "@washingtonpost/wpds-icon": "1.5.2",
         "@washingtonpost/wpds-input-text": "1.5.2"
       },
@@ -49608,7 +49609,7 @@
         "typescript": "4.5.5"
       },
       "peerDependencies": {
-        "@washingtonpost/wpds-assets": "^1.18.0",
+        "@washingtonpost/wpds-assets": "^1.19.2",
         "@washingtonpost/wpds-icon": "*",
         "@washingtonpost/wpds-input-text": "*",
         "react": "^16.8.6 || ^17.0.2"
@@ -49648,7 +49649,7 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-label": "^1.0.0",
-        "@washingtonpost/wpds-assets": "^1.18.0",
+        "@washingtonpost/wpds-assets": "^1.19.2",
         "@washingtonpost/wpds-box": "1.5.2",
         "@washingtonpost/wpds-button": "1.5.2",
         "@washingtonpost/wpds-error-message": "1.5.2",
@@ -49665,7 +49666,7 @@
         "typescript": "4.5.5"
       },
       "peerDependencies": {
-        "@washingtonpost/wpds-assets": "^1.18.0",
+        "@washingtonpost/wpds-assets": "^1.19.2",
         "@washingtonpost/wpds-box": "*",
         "@washingtonpost/wpds-button": "*",
         "@washingtonpost/wpds-error-message": "*",
@@ -49895,7 +49896,7 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-popover": "^1.0.2",
-        "@washingtonpost/wpds-assets": "^1.18.0",
+        "@washingtonpost/wpds-assets": "^1.19.2",
         "@washingtonpost/wpds-button": "1.5.2",
         "@washingtonpost/wpds-icon": "1.5.2",
         "@washingtonpost/wpds-theme": "1.5.2"
@@ -49905,7 +49906,7 @@
         "typescript": "4.5.5"
       },
       "peerDependencies": {
-        "@washingtonpost/wpds-theme": "^1.18.0",
+        "@washingtonpost/wpds-theme": "^1.19.2",
         "react": "^16.8.6 || ^17.0.2"
       }
     },
@@ -50057,7 +50058,7 @@
       "dependencies": {
         "@radix-ui/react-select": "^1.0.0",
         "@radix-ui/react-use-controllable-state": "^1.0.0",
-        "@washingtonpost/wpds-assets": "^1.18.0",
+        "@washingtonpost/wpds-assets": "^1.19.2",
         "@washingtonpost/wpds-divider": "1.5.2",
         "@washingtonpost/wpds-icon": "1.5.2",
         "@washingtonpost/wpds-input-label": "1.5.2",
@@ -50072,7 +50073,7 @@
       "peerDependencies": {
         "@radix-ui/react-select": "^1.0.0",
         "@radix-ui/react-use-controllable-state": "^1.0.0",
-        "@washingtonpost/wpds-assets": "^1.18.0",
+        "@washingtonpost/wpds-assets": "^1.19.2",
         "@washingtonpost/wpds-divider": "*",
         "@washingtonpost/wpds-icon": "*",
         "@washingtonpost/wpds-input-label": "*",
@@ -62061,7 +62062,7 @@
       "version": "file:ui/accordion",
       "requires": {
         "@radix-ui/react-accordion": "latest",
-        "@washingtonpost/wpds-assets": "^1.18.0",
+        "@washingtonpost/wpds-assets": "^1.19.2",
         "@washingtonpost/wpds-icon": "1.5.2",
         "@washingtonpost/wpds-theme": "1.5.2",
         "tsup": "5.11.13",
@@ -62127,7 +62128,7 @@
       "version": "file:ui/alert-banner",
       "requires": {
         "@washingtonpost/wpds-app-bar": "1.5.2",
-        "@washingtonpost/wpds-assets": "^1.18.0",
+        "@washingtonpost/wpds-assets": "^1.19.2",
         "@washingtonpost/wpds-button": "1.5.2",
         "@washingtonpost/wpds-container": "1.5.2",
         "@washingtonpost/wpds-icon": "1.5.2",
@@ -62156,7 +62157,9 @@
       }
     },
     "@washingtonpost/wpds-assets": {
-      "version": "1.18.0",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-assets/-/wpds-assets-1.19.2.tgz",
+      "integrity": "sha512-+1dfcnQRxkGXtZB+5wtGT97JqqgJ8tie+Pv05ujaV06pXTdNSorkV403EpFQEzinT0sTBEslI8QGJW8uK9OHRw==",
       "requires": {
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
@@ -62222,7 +62225,7 @@
       "requires": {
         "@radix-ui/react-slot": "^1.0.0",
         "@radix-ui/react-use-controllable-state": "^1.0.0",
-        "@washingtonpost/wpds-assets": "^1.18.0",
+        "@washingtonpost/wpds-assets": "^1.19.2",
         "@washingtonpost/wpds-button": "1.5.2",
         "@washingtonpost/wpds-icon": "1.5.2",
         "@washingtonpost/wpds-pagination-dots": "1.5.2",
@@ -62237,7 +62240,7 @@
       "version": "file:ui/checkbox",
       "requires": {
         "@radix-ui/react-checkbox": "^1.0.0",
-        "@washingtonpost/wpds-assets": "^1.18.0",
+        "@washingtonpost/wpds-assets": "^1.19.2",
         "@washingtonpost/wpds-icon": "1.5.2",
         "@washingtonpost/wpds-input-label": "1.5.2",
         "@washingtonpost/wpds-input-shared": "1.5.2",
@@ -62344,7 +62347,7 @@
         "@washingtonpost/site-favicons": "^0.1.3",
         "@washingtonpost/tachyons-css": "^1.7.0",
         "@washingtonpost/wpds-accordion": "1.5.2",
-        "@washingtonpost/wpds-assets": "1.19.1",
+        "@washingtonpost/wpds-assets": "^1.19.2",
         "@washingtonpost/wpds-kitchen-sink": "1.5.2",
         "@washingtonpost/wpds-ui-kit": "1.5.2",
         "babel-plugin-extract-react-types": "^0.1.14",
@@ -62564,8 +62567,8 @@
           }
         },
         "@washingtonpost/wpds-assets": {
-          "version": "1.19.1",
-          "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-assets/-/wpds-assets-1.19.1.tgz",
+          "version": "1.19.2",
+          "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-assets/-/wpds-assets-1.19.2.tgz",
           "integrity": "sha512-Ad9MahGaiPMMFJ7+ny4uk71Vpusg4ScPDeDP8u3R1CsWfOj4mZ73JEusKbQSZitemJzB48RVBnk52PAHkRIRZg==",
           "requires": {
             "react": "^16.0.1 || ^17.0.2",
@@ -62710,7 +62713,7 @@
       "version": "file:ui/drawer",
       "requires": {
         "@radix-ui/react-focus-scope": "^1.0.0",
-        "@washingtonpost/wpds-assets": "^1.18.0",
+        "@washingtonpost/wpds-assets": "^1.19.2",
         "@washingtonpost/wpds-button": "1.5.2",
         "@washingtonpost/wpds-icon": "1.5.2",
         "@washingtonpost/wpds-scrim": "1.5.2",
@@ -62802,7 +62805,7 @@
     "@washingtonpost/wpds-input-password": {
       "version": "file:ui/input-password",
       "requires": {
-        "@washingtonpost/wpds-assets": "^1.18.0",
+        "@washingtonpost/wpds-assets": "^1.19.2",
         "@washingtonpost/wpds-icon": "1.5.2",
         "@washingtonpost/wpds-input-text": "1.5.2",
         "tsup": "5.11.13",
@@ -62830,7 +62833,7 @@
       "version": "file:ui/input-text",
       "requires": {
         "@radix-ui/react-label": "^1.0.0",
-        "@washingtonpost/wpds-assets": "^1.18.0",
+        "@washingtonpost/wpds-assets": "^1.19.2",
         "@washingtonpost/wpds-box": "1.5.2",
         "@washingtonpost/wpds-button": "1.5.2",
         "@washingtonpost/wpds-error-message": "1.5.2",
@@ -62928,7 +62931,7 @@
       "version": "file:ui/popover",
       "requires": {
         "@radix-ui/react-popover": "^1.0.2",
-        "@washingtonpost/wpds-assets": "^1.18.0",
+        "@washingtonpost/wpds-assets": "^1.19.2",
         "@washingtonpost/wpds-button": "1.5.2",
         "@washingtonpost/wpds-icon": "1.5.2",
         "@washingtonpost/wpds-theme": "1.5.2",
@@ -63033,7 +63036,7 @@
       "requires": {
         "@radix-ui/react-select": "^1.0.0",
         "@radix-ui/react-use-controllable-state": "^1.0.0",
-        "@washingtonpost/wpds-assets": "^1.18.0",
+        "@washingtonpost/wpds-assets": "^1.19.2",
         "@washingtonpost/wpds-divider": "1.5.2",
         "@washingtonpost/wpds-icon": "1.5.2",
         "@washingtonpost/wpds-input-label": "1.5.2",
@@ -77392,7 +77395,7 @@
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
+        "es-abstract": "^1.19.2"
       }
     },
     "object.fromentries": {
@@ -77401,7 +77404,7 @@
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
+        "es-abstract": "^1.19.2"
       }
     },
     "object.getownpropertydescriptors": {
@@ -77443,7 +77446,7 @@
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
+        "es-abstract": "^1.19.2"
       }
     },
     "objectorarray": {
@@ -81205,7 +81208,7 @@
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1",
+        "es-abstract": "^1.19.2",
         "get-intrinsic": "^1.1.1",
         "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
@@ -81237,7 +81240,7 @@
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
+        "es-abstract": "^1.19.2"
       }
     },
     "string.prototype.trimend": {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   ],
   "dependencies": {
     "@babel/standalone": "^7.17.11",
-    "@washingtonpost/wpds-assets": "^1.18.0",
+    "@washingtonpost/wpds-assets": "^1.19.2",
     "typescript": "4.5.5"
   },
   "scripts": {
@@ -177,7 +177,7 @@
     "react-docgen-typescript": "^2.2.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "@washingtonpost/wpds-assets": "^1.18.0"
+    "@washingtonpost/wpds-assets": "^1.19.2"
   },
   "packageManager": "npm@8.11.0"
 }

--- a/ui/accordion/package.json
+++ b/ui/accordion/package.json
@@ -37,14 +37,14 @@
   },
   "peerDependencies": {
     "@radix-ui/react-accordion": "latest",
-    "@washingtonpost/wpds-assets": "^1.18.0",
+    "@washingtonpost/wpds-assets": "^1.19.2",
     "@washingtonpost/wpds-icon": "*",
     "@washingtonpost/wpds-theme": "*",
     "react": "^16.8.6 || ^17.0.2"
   },
   "dependencies": {
     "@radix-ui/react-accordion": "latest",
-    "@washingtonpost/wpds-assets": "^1.18.0",
+    "@washingtonpost/wpds-assets": "^1.19.2",
     "@washingtonpost/wpds-icon": "1.5.2",
     "@washingtonpost/wpds-theme": "1.5.2"
   },

--- a/ui/alert-banner/package.json
+++ b/ui/alert-banner/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "@washingtonpost/wpds-app-bar": "*",
-    "@washingtonpost/wpds-assets": "^1.18.0",
+    "@washingtonpost/wpds-assets": "^1.19.2",
     "@washingtonpost/wpds-button": "*",
     "@washingtonpost/wpds-container": "*",
     "@washingtonpost/wpds-icon": "*",
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@washingtonpost/wpds-app-bar": "1.5.2",
-    "@washingtonpost/wpds-assets": "^1.18.0",
+    "@washingtonpost/wpds-assets": "^1.19.2",
     "@washingtonpost/wpds-button": "1.5.2",
     "@washingtonpost/wpds-container": "1.5.2",
     "@washingtonpost/wpds-icon": "1.5.2",

--- a/ui/carousel/package.json
+++ b/ui/carousel/package.json
@@ -36,7 +36,7 @@
     "typescript": "4.5.5"
   },
   "peerDependencies": {
-    "@washingtonpost/wpds-assets": "^1.18.0",
+    "@washingtonpost/wpds-assets": "^1.19.2",
     "@washingtonpost/wpds-button": "*",
     "@washingtonpost/wpds-icon": "*",
     "@washingtonpost/wpds-pagination-dots": "*",
@@ -46,7 +46,7 @@
   "dependencies": {
     "@radix-ui/react-slot": "^1.0.0",
     "@radix-ui/react-use-controllable-state": "^1.0.0",
-    "@washingtonpost/wpds-assets": "^1.18.0",
+    "@washingtonpost/wpds-assets": "^1.19.2",
     "@washingtonpost/wpds-button": "1.5.2",
     "@washingtonpost/wpds-icon": "1.5.2",
     "@washingtonpost/wpds-pagination-dots": "1.5.2",

--- a/ui/checkbox/package.json
+++ b/ui/checkbox/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "@radix-ui/react-checkbox": "^1.0.0",
-    "@washingtonpost/wpds-assets": "^1.18.0",
+    "@washingtonpost/wpds-assets": "^1.19.2",
     "@washingtonpost/wpds-icon": "*",
     "@washingtonpost/wpds-input-label": "*",
     "@washingtonpost/wpds-input-shared": "*",
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.0.0",
-    "@washingtonpost/wpds-assets": "^1.18.0",
+    "@washingtonpost/wpds-assets": "^1.19.2",
     "@washingtonpost/wpds-icon": "1.5.2",
     "@washingtonpost/wpds-input-label": "1.5.2",
     "@washingtonpost/wpds-input-shared": "1.5.2",

--- a/ui/drawer/package.json
+++ b/ui/drawer/package.json
@@ -36,7 +36,7 @@
     "typescript": "4.5.5"
   },
   "peerDependencies": {
-    "@washingtonpost/wpds-assets": "^1.18.0",
+    "@washingtonpost/wpds-assets": "^1.19.2",
     "@washingtonpost/wpds-button": "*",
     "@washingtonpost/wpds-icon": "*",
     "@washingtonpost/wpds-scrim": "*",
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@radix-ui/react-focus-scope": "^1.0.0",
-    "@washingtonpost/wpds-assets": "^1.18.0",
+    "@washingtonpost/wpds-assets": "^1.19.2",
     "@washingtonpost/wpds-button": "1.5.2",
     "@washingtonpost/wpds-icon": "1.5.2",
     "@washingtonpost/wpds-scrim": "1.5.2",

--- a/ui/input-password/package.json
+++ b/ui/input-password/package.json
@@ -36,13 +36,13 @@
     "typescript": "4.5.5"
   },
   "peerDependencies": {
-    "@washingtonpost/wpds-assets": "^1.18.0",
+    "@washingtonpost/wpds-assets": "^1.19.2",
     "@washingtonpost/wpds-icon": "*",
     "@washingtonpost/wpds-input-text": "*",
     "react": "^16.8.6 || ^17.0.2"
   },
   "dependencies": {
-    "@washingtonpost/wpds-assets": "^1.18.0",
+    "@washingtonpost/wpds-assets": "^1.19.2",
     "@washingtonpost/wpds-icon": "1.5.2",
     "@washingtonpost/wpds-input-text": "1.5.2"
   },

--- a/ui/input-text/package.json
+++ b/ui/input-text/package.json
@@ -36,7 +36,7 @@
     "typescript": "4.5.5"
   },
   "peerDependencies": {
-    "@washingtonpost/wpds-assets": "^1.18.0",
+    "@washingtonpost/wpds-assets": "^1.19.2",
     "@washingtonpost/wpds-box": "*",
     "@washingtonpost/wpds-button": "*",
     "@washingtonpost/wpds-error-message": "*",
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@radix-ui/react-label": "^1.0.0",
-    "@washingtonpost/wpds-assets": "^1.18.0",
+    "@washingtonpost/wpds-assets": "^1.19.2",
     "@washingtonpost/wpds-box": "1.5.2",
     "@washingtonpost/wpds-button": "1.5.2",
     "@washingtonpost/wpds-error-message": "1.5.2",

--- a/ui/popover/package.json
+++ b/ui/popover/package.json
@@ -36,12 +36,12 @@
     "typescript": "4.5.5"
   },
   "peerDependencies": {
-    "@washingtonpost/wpds-theme": "^1.18.0",
+    "@washingtonpost/wpds-theme": "^1.19.2",
     "react": "^16.8.6 || ^17.0.2"
   },
   "dependencies": {
     "@radix-ui/react-popover": "^1.0.2",
-    "@washingtonpost/wpds-assets": "^1.18.0",
+    "@washingtonpost/wpds-assets": "^1.19.2",
     "@washingtonpost/wpds-button": "1.5.2",
     "@washingtonpost/wpds-icon": "1.5.2",
     "@washingtonpost/wpds-theme": "1.5.2"

--- a/ui/select/package.json
+++ b/ui/select/package.json
@@ -38,7 +38,7 @@
   "peerDependencies": {
     "@radix-ui/react-select": "^1.0.0",
     "@radix-ui/react-use-controllable-state": "^1.0.0",
-    "@washingtonpost/wpds-assets": "^1.18.0",
+    "@washingtonpost/wpds-assets": "^1.19.2",
     "@washingtonpost/wpds-divider": "*",
     "@washingtonpost/wpds-icon": "*",
     "@washingtonpost/wpds-input-label": "*",
@@ -49,7 +49,7 @@
   "dependencies": {
     "@radix-ui/react-select": "^1.0.0",
     "@radix-ui/react-use-controllable-state": "^1.0.0",
-    "@washingtonpost/wpds-assets": "^1.18.0",
+    "@washingtonpost/wpds-assets": "^1.19.2",
     "@washingtonpost/wpds-divider": "1.5.2",
     "@washingtonpost/wpds-icon": "1.5.2",
     "@washingtonpost/wpds-input-label": "1.5.2",


### PR DESCRIPTION
## What I did
Following up on https://github.com/washingtonpost/wpds-assets-manager/pull/103, this PR updates the package in the build site to verify that the logo colors changed as expected.

## Testing steps
View [the updated logos on the deployment link](https://wpds-ui-ksjjahffq.preview.now.washingtonpost.com/foundations/logos).