### PR TITLE
chore: upgrade wpds-assets to 1.19.2 in build.washingtonpost.com

### DIFF
--- a/build.washingtonpost.com/package.json
+++ b/build.washingtonpost.com/package.json
@@ -24,7 +24,7 @@
     "@washingtonpost/site-favicons": "^0.1.3",
     "@washingtonpost/tachyons-css": "^1.7.0",
     "@washingtonpost/wpds-accordion": "1.5.2",
-    "@washingtonpost/wpds-assets": "^1.19.0",
+    "@washingtonpost/wpds-assets": "^1.19.2",
     "@washingtonpost/wpds-kitchen-sink": "1.5.2",
     "@washingtonpost/wpds-ui-kit": "1.5.2",
     "fuse.js": "^6.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -709,7 +709,7 @@
         "@washingtonpost/site-favicons": "^0.1.3",
         "@washingtonpost/tachyons-css": "^1.7.0",
         "@washingtonpost/wpds-accordion": "1.5.2",
-        "@washingtonpost/wpds-assets": "^1.19.0",
+        "@washingtonpost/wpds-assets": "^1.19.2",
         "@washingtonpost/wpds-kitchen-sink": "1.5.2",
         "@washingtonpost/wpds-ui-kit": "1.5.2",
         "fuse.js": "^6.6.2",
@@ -1043,9 +1043,9 @@
       }
     },
     "build.washingtonpost.com/node_modules/@washingtonpost/wpds-assets": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-assets/-/wpds-assets-1.19.0.tgz",
-      "integrity": "sha512-C5J5iQdfHBJCKrdnvbjIPTndFez6/Zn9IJLHc/jrC7wQUJsaZbcVxYBgrhOyXw2r+6BO6gso0zINO6iopLzo0A==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-assets/-/wpds-assets-1.19.2.tgz",
+      "integrity": "sha512-+1dfcnQRxkGXtZB+5wtGT97JqqgJ8tie+Pv05ujaV06pXTdNSorkV403EpFQEzinT0sTBEslI8QGJW8uK9OHRw==",
       "dependencies": {
         "react": "^16.0.1 || ^17.0.2",
         "react-dom": "^16.0.1 || ^17.0.2"
@@ -62344,7 +62344,7 @@
         "@washingtonpost/site-favicons": "^0.1.3",
         "@washingtonpost/tachyons-css": "^1.7.0",
         "@washingtonpost/wpds-accordion": "1.5.2",
-        "@washingtonpost/wpds-assets": "^1.19.0",
+        "@washingtonpost/wpds-assets": "^1.19.2",
         "@washingtonpost/wpds-kitchen-sink": "1.5.2",
         "@washingtonpost/wpds-ui-kit": "1.5.2",
         "babel-plugin-extract-react-types": "^0.1.14",
@@ -62564,9 +62564,9 @@
           }
         },
         "@washingtonpost/wpds-assets": {
-          "version": "1.19.0",
-          "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-assets/-/wpds-assets-1.19.0.tgz",
-          "integrity": "sha512-C5J5iQdfHBJCKrdnvbjIPTndFez6/Zn9IJLHc/jrC7wQUJsaZbcVxYBgrhOyXw2r+6BO6gso0zINO6iopLzo0A==",
+          "version": "1.19.2",
+          "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-assets/-/wpds-assets-1.19.2.tgz",
+          "integrity": "sha512-+1dfcnQRxkGXtZB+5wtGT97JqqgJ8tie+Pv05ujaV06pXTdNSorkV403EpFQEzinT0sTBEslI8QGJW8uK9OHRw==",
           "requires": {
             "react": "^16.0.1 || ^17.0.2",
             "react-dom": "^16.0.1 || ^17.0.2"


### PR DESCRIPTION
## What I did
The logos have the expected #111 now instead of gray. Yay!

<img width="1493" alt="Screenshot 2023-05-17 at 1 28 45 PM" src="https://github.com/washingtonpost/wpds-ui-kit/assets/38192823/85d70256-b843-49c1-a4bf-1c57775f90cb">
