### PR TITLE
fix: add underline to hyperlinks in build site markdown [SRED-242]

### DIFF
--- a/build.washingtonpost.com/components/Markdown/Components/link.js
+++ b/build.washingtonpost.com/components/Markdown/Components/link.js
@@ -13,6 +13,7 @@ export default function CustomLink({
 }) {
   const A = styled("a", {
     cursor: "pointer",
+    textDecoration: "underline",
     color: "$primary",
     "&:hover": {
       opacity: ".75",


### PR DESCRIPTION
## What I did
Quick fix to add underlines back to links on the build site - following up on this with [SRED-215](https://arcpublishing.atlassian.net/browse/SRED-215) eventually


[SRED-215]: https://arcpublishing.atlassian.net/browse/SRED-215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ