### PR TITLE
fix: a11y improvements to welcome page and broader page landmarks on build site

### DIFF
--- a/build.washingtonpost.com/components/Contributors.jsx
+++ b/build.washingtonpost.com/components/Contributors.jsx
@@ -28,21 +28,21 @@ const StyledContributorHeader = styled(Header, {
 });
 
 const ContributorBlock = ({ contributor }) => (
-  <StyledContributor>
-    <CustomLink href={contributor.url}>
+  <StyledContributor >
+    <CustomLink aria-hidden="true" tabIndex="-1" href={contributor.url}>
       <Avatar size="600">
         <Image
           height="100"
           width="100"
           layout="fixed"
           src={contributor.avatar}
-          alt={contributor.name}
+          alt=""
         />
       </Avatar>
     </CustomLink>
     <div>
       <CustomLink href={contributor.url}>
-        <Header as="h4">{contributor.name}</Header>
+        <Header as="h3">{contributor.name}</Header>
       </CustomLink>
     </div>
   </StyledContributor>

--- a/build.washingtonpost.com/components/Layout/Components/Sidebar.js
+++ b/build.washingtonpost.com/components/Layout/Components/Sidebar.js
@@ -228,7 +228,7 @@ export default function Sidebar({ navigation, setMobileMenu }) {
   };
   return (
     <Panel id="open-nav">
-      <Container id="sidebar-container">
+      <Container id="sidebar-container" as="nav" aria-label="Sections" >
         {navigation &&
           navigation.map((nav, index) => {
             return (

--- a/build.washingtonpost.com/components/NavigationBar.js
+++ b/build.washingtonpost.com/components/NavigationBar.js
@@ -149,7 +149,7 @@ export const NavigationBar = ({ setMobileMenu, mobileMenuState, isClosed }) => {
 
   return (
     <>
-      <Container>
+      <Container as="header">
         <SkipToMainContent as="a" href="#main">
           Skip to main content
         </SkipToMainContent>
@@ -193,7 +193,7 @@ export const NavigationBar = ({ setMobileMenu, mobileMenuState, isClosed }) => {
           </Button>
         </Box>
       </Container>
-      <List>
+      <List role="navigation" aria-label="Support and search">
         <ListItem>
           <Link href="/release-notes" passHref>
             <Anchor

--- a/build.washingtonpost.com/components/Typography/link.js
+++ b/build.washingtonpost.com/components/Typography/link.js
@@ -11,7 +11,9 @@ export const A = styled("a", {
   },
   "&:focus-visible": {
     outline: "1px auto Highlight",
-    outline: "1px auto -webkit-focus-ring-color"
+    "@media screen and (-webkit-min-device-pixel-ratio: 0)": {
+      outline: "1px auto -webkit-focus-ring-color",
+    },
   },
   variants: {
     signal: {

--- a/build.washingtonpost.com/components/Typography/link.js
+++ b/build.washingtonpost.com/components/Typography/link.js
@@ -9,11 +9,9 @@ export const A = styled("a", {
   "&:hover": {
     opacity: ".75",
   },
-  "&:focus": {
-    outlineColor: "$signal",
-    outlineStyle: "solid",
-    outlineOffset: "2px",
-    outlineWidth: "2px",
+  "&:focus-visible": {
+    outline: "1px auto Highlight",
+    outline: "1px auto -webkit-focus-ring-color"
   },
   variants: {
     signal: {

--- a/build.washingtonpost.com/pages/index.js
+++ b/build.washingtonpost.com/pages/index.js
@@ -148,7 +148,9 @@ const Index = ({ recentPosts, rankedArticles, contributors }) => {
           css={{
             "&:focus-within": {
               outline: "1px auto Highlight",
-              outline: "1px auto -webkit-focus-ring-color"
+              "@media screen and (-webkit-min-device-pixel-ratio: 0)": {
+                outline: "1px auto -webkit-focus-ring-color",
+              },
             },
             position: "relative",
             "@md": {
@@ -192,7 +194,9 @@ const Index = ({ recentPosts, rankedArticles, contributors }) => {
           css={{
             "&:focus-within": {
               outline: "1px auto Highlight",
-              outline: "1px auto -webkit-focus-ring-color"
+              "@media screen and (-webkit-min-device-pixel-ratio: 0)": {
+                outline: "1px auto -webkit-focus-ring-color",
+              },
             },
             position: "relative",
             "@md": {
@@ -240,7 +244,9 @@ const Index = ({ recentPosts, rankedArticles, contributors }) => {
           css={{
             "&:focus-within": {
               outline: "1px auto Highlight",
-              outline: "1px auto -webkit-focus-ring-color"
+              "@media screen and (-webkit-min-device-pixel-ratio: 0)": {
+                outline: "1px auto -webkit-focus-ring-color",
+              },
             },
             height: "100%",
             position: "relative",

--- a/build.washingtonpost.com/pages/index.js
+++ b/build.washingtonpost.com/pages/index.js
@@ -66,7 +66,17 @@ const Index = ({ recentPosts, rankedArticles, contributors }) => {
             "@sm": { display: "none" },
           }}
         >
-          <Header href="/resources" as="h3">
+          <Header
+            href="/resources"
+            as="h2"
+            css={{
+              fontSize: "$125",
+              fontFamily: "$subhead",
+              fontWeight: "$bold",
+              marginBottom: "$025",
+              marginTop: "$100",
+            }}
+          >
             What&apos;s new
           </Header>
         </Box>
@@ -136,6 +146,10 @@ const Index = ({ recentPosts, rankedArticles, contributors }) => {
       <LandingContentGrid size="wide">
         <Box
           css={{
+            "&:focus-within": {
+              outline: "1px auto Highlight",
+              outline: "1px auto -webkit-focus-ring-color"
+            },
             position: "relative",
             "@md": {
               gridColumn: "1/-1",
@@ -151,7 +165,7 @@ const Index = ({ recentPosts, rankedArticles, contributors }) => {
               width="320"
               layout="responsive"
               src="/img/sections/foundations.png"
-              alt="Image shows the word 'Foundations' in large bold letters in front of two squiggly cirles. The words 'WP Design System' in small letters above the bold letters."
+              alt=""
             />
             <Header as="h3">Foundations</Header>
             <P
@@ -176,6 +190,10 @@ const Index = ({ recentPosts, rankedArticles, contributors }) => {
         </Box>
         <Box
           css={{
+            "&:focus-within": {
+              outline: "1px auto Highlight",
+              outline: "1px auto -webkit-focus-ring-color"
+            },
             position: "relative",
             "@md": {
               gridColumn: "1/-1",
@@ -195,7 +213,7 @@ const Index = ({ recentPosts, rankedArticles, contributors }) => {
               width="320"
               layout="responsive"
               src="/img/sections/components.png"
-              alt="Image shows the word 'Components' in large bold letters in front of two squiggly cirles. The words 'WP Design System' in small letters above the bold letters."
+              alt=""
             />
             <Header as="h3">Components</Header>
             <P
@@ -220,6 +238,10 @@ const Index = ({ recentPosts, rankedArticles, contributors }) => {
         </Box>
         <Box
           css={{
+            "&:focus-within": {
+              outline: "1px auto Highlight",
+              outline: "1px auto -webkit-focus-ring-color"
+            },
             height: "100%",
             position: "relative",
             "@md": {
@@ -236,7 +258,7 @@ const Index = ({ recentPosts, rankedArticles, contributors }) => {
               width="320"
               layout="responsive"
               src="/img/sections/resources.png"
-              alt="Image shows the word 'Resources' in large bold letters in front of two squiggly cirles. The words 'WP Design System' in small letters above the bold letters."
+              alt=""
             />
             <Header as="h3">Resources</Header>
             <P
@@ -296,7 +318,7 @@ const Index = ({ recentPosts, rankedArticles, contributors }) => {
                       width="500"
                       layout="responsive"
                       src={article.data.imageTag}
-                      alt={article.data.imageAltText}
+                      alt=""
                     />
                   </Box>
                   <Box


### PR DESCRIPTION
## What I did
These fixes to the "Welcome" page (and navigation menus) address some feedback we received about the site in the design systems slack.

- Made focus styles consistent (per browser defaults)
- Added proper page landmarks for screen reader accessibility
- Removed alt text that was on purely decorative images
- Hide redundant links to improve both keyboard and screen reader navigation
- Corrected heading order
