### PR TITLE
docs: clean up typos and clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm i @washingtonpost/wpds-ui-kit
 ## Additional Information
 
 - Read about how to build a feature for your React site using our UI Kit on our [React Guide](https://build.washingtonpost.com/resources/guides/react-guide).
-- If you would like to contribute to you our WPDS UI Kit please refer to the [contribution docs](docs/CONTRIBUTING.md).
+- If you would like to contribute to our WPDS UI Kit please refer to the [contribution docs](docs/CONTRIBUTING.md).
 - Feel free to reach out to [#wpds on Slack](https://washpost.slack.com/archives/C01FWHF12BG) if you have any questions or run into any problems.
 - [Explore the Docs Site](https://build.washingtonpost.com) for usage examples and additional documentation on each component. You can also find additional resources under the [resources](https://build.washingtonpost.com/resources), [guides](https://build.washingtonpost.com/resources/guides), and [support](https://build.washingtonpost.com/support) pages.
 - There is also a storybook site that is used for component development only. If you're looking for code examples or information on how to use a specific component, please refer to build.washingtonpost.com.

--- a/build.washingtonpost.com/README.md
+++ b/build.washingtonpost.com/README.md
@@ -24,7 +24,7 @@ npm ci
 npm run build
 ```
 
-5. Open http://localhost:3000
+5. To open http://localhost:3000
 
 ```
 npm run dev --workspace=build.washingtonpost.com

--- a/build.washingtonpost.com/docs/components/switch.mdx
+++ b/build.washingtonpost.com/docs/components/switch.mdx
@@ -135,7 +135,7 @@ When making switches required always pair it with a label that has the required 
 
 ### Switches control binary options
 
-Don’t use switches to control options that do not control a single state that can clearly be categorized as `on` or `off`
+Don’t use switches to control states that cannot clearly be categorized as either `on` or `off`.
 
 ```jsx withPreview isGuide="error"
 <FlexColumn gap="050">

--- a/build.washingtonpost.com/docs/foundations/wam.mdx
+++ b/build.washingtonpost.com/docs/foundations/wam.mdx
@@ -18,7 +18,7 @@ description: WPDS Asset-Manager (also known as WAM) manages all assets as raw SV
 
 ## Getting started
 
-### How to use in figma
+### How to use in Figma
 
 To use WAM, please enable the
 [WPDS-Asset-Manager](https://www.figma.com/file/LA6qKUukk8v3YkkuKq6IC6/%F0%9F%96%BC--WPDS-Asset-Manager)


### PR DESCRIPTION
## What I did

Fixed a few typos or things I found unclear in the READMEs and docs.
