### PR TITLE
chore: updated site map and packagelock for new release

### DIFF
--- a/build.washingtonpost.com/public/sitemap.xml
+++ b/build.washingtonpost.com/public/sitemap.xml
@@ -279,6 +279,12 @@
   </url>
 
   <url>
+    <loc
+      >https://build.washingtonpost.com/resources/guides/performance-and-seo</loc
+    >
+  </url>
+
+  <url>
     <loc>https://build.washingtonpost.com/resources/guides/react-guide</loc>
   </url>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -110,10 +110,10 @@
       }
     },
     "apps/vite-project": {
-      "version": "1.7.1",
+      "version": "1.8.0",
       "dependencies": {
-        "@washingtonpost/wpds-kitchen-sink": "1.7.1",
-        "@washingtonpost/wpds-ui-kit": "1.7.1",
+        "@washingtonpost/wpds-kitchen-sink": "1.8.0",
+        "@washingtonpost/wpds-ui-kit": "1.8.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -176,10 +176,10 @@
       }
     },
     "apps/vite-v2-project": {
-      "version": "1.7.1",
+      "version": "1.8.0",
       "dependencies": {
-        "@washingtonpost/wpds-kitchen-sink": "1.7.1",
-        "@washingtonpost/wpds-ui-kit": "1.7.1",
+        "@washingtonpost/wpds-kitchen-sink": "1.8.0",
+        "@washingtonpost/wpds-ui-kit": "1.8.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
       },
@@ -694,7 +694,7 @@
     },
     "build.washingtonpost.com": {
       "name": "@washingtonpost/wpds-docs",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/standalone": "^7.17.11",
@@ -708,11 +708,11 @@
         "@stitches/react": "1.2.8",
         "@washingtonpost/site-favicons": "^0.1.3",
         "@washingtonpost/tachyons-css": "^1.8.0",
-        "@washingtonpost/wpds-accordion": "1.7.1",
+        "@washingtonpost/wpds-accordion": "1.8.0",
         "@washingtonpost/wpds-assets": "1.20.0",
-        "@washingtonpost/wpds-kitchen-sink": "1.7.1",
-        "@washingtonpost/wpds-tailwind-theme": "1.7.1",
-        "@washingtonpost/wpds-ui-kit": "1.7.1",
+        "@washingtonpost/wpds-kitchen-sink": "1.8.0",
+        "@washingtonpost/wpds-tailwind-theme": "1.8.0",
+        "@washingtonpost/wpds-ui-kit": "1.8.0",
         "fuse.js": "^6.6.2",
         "gray-matter": "^4.0.2",
         "lz-string": "^1.4.4",
@@ -48856,13 +48856,13 @@
     },
     "ui/accordion": {
       "name": "@washingtonpost/wpds-accordion",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-accordion": "latest",
         "@washingtonpost/wpds-assets": "^1.18.0",
-        "@washingtonpost/wpds-icon": "1.7.1",
-        "@washingtonpost/wpds-theme": "1.7.1"
+        "@washingtonpost/wpds-icon": "1.8.0",
+        "@washingtonpost/wpds-theme": "1.8.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -48956,15 +48956,15 @@
     },
     "ui/alert-banner": {
       "name": "@washingtonpost/wpds-alert-banner",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-app-bar": "1.7.1",
+        "@washingtonpost/wpds-app-bar": "1.8.0",
         "@washingtonpost/wpds-assets": "^1.18.0",
-        "@washingtonpost/wpds-button": "1.7.1",
-        "@washingtonpost/wpds-container": "1.7.1",
-        "@washingtonpost/wpds-icon": "1.7.1",
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-button": "1.8.0",
+        "@washingtonpost/wpds-container": "1.8.0",
+        "@washingtonpost/wpds-icon": "1.8.0",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {
@@ -48995,10 +48995,10 @@
     },
     "ui/app-bar": {
       "name": "@washingtonpost/wpds-app-bar",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {
@@ -49012,11 +49012,11 @@
     },
     "ui/avatar": {
       "name": "@washingtonpost/wpds-avatar",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-avatar": "latest",
-        "@washingtonpost/wpds-theme": "1.7.1"
+        "@washingtonpost/wpds-theme": "1.8.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -49046,10 +49046,10 @@
     },
     "ui/box": {
       "name": "@washingtonpost/wpds-box",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {
@@ -49063,10 +49063,10 @@
     },
     "ui/button": {
       "name": "@washingtonpost/wpds-button",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {
@@ -49080,10 +49080,10 @@
     },
     "ui/card": {
       "name": "@washingtonpost/wpds-card",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.7.1"
+        "@washingtonpost/wpds-theme": "1.8.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -49096,16 +49096,16 @@
     },
     "ui/carousel": {
       "name": "@washingtonpost/wpds-carousel",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "^1.0.0",
         "@radix-ui/react-use-controllable-state": "^1.0.0",
         "@washingtonpost/wpds-assets": "^1.18.0",
-        "@washingtonpost/wpds-button": "1.7.1",
-        "@washingtonpost/wpds-icon": "1.7.1",
-        "@washingtonpost/wpds-pagination-dots": "1.7.1",
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-button": "1.8.0",
+        "@washingtonpost/wpds-icon": "1.8.0",
+        "@washingtonpost/wpds-pagination-dots": "1.8.0",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "nanoid": "^3.3.4",
         "react-swipeable": "^7.0.0"
       },
@@ -49124,16 +49124,16 @@
     },
     "ui/checkbox": {
       "name": "@washingtonpost/wpds-checkbox",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.0.0",
         "@washingtonpost/wpds-assets": "^1.18.0",
-        "@washingtonpost/wpds-icon": "1.7.1",
-        "@washingtonpost/wpds-input-label": "1.7.1",
-        "@washingtonpost/wpds-input-shared": "1.7.1",
-        "@washingtonpost/wpds-theme": "1.7.1",
-        "@washingtonpost/wpds-visually-hidden": "1.7.1",
+        "@washingtonpost/wpds-icon": "1.8.0",
+        "@washingtonpost/wpds-input-label": "1.8.0",
+        "@washingtonpost/wpds-input-shared": "1.8.0",
+        "@washingtonpost/wpds-theme": "1.8.0",
+        "@washingtonpost/wpds-visually-hidden": "1.8.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {
@@ -49207,10 +49207,10 @@
     },
     "ui/container": {
       "name": "@washingtonpost/wpds-container",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {
@@ -49224,11 +49224,11 @@
     },
     "ui/divider": {
       "name": "@washingtonpost/wpds-divider",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-separator": "^1.0.0",
-        "@washingtonpost/wpds-theme": "1.7.1"
+        "@washingtonpost/wpds-theme": "1.8.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -49265,15 +49265,15 @@
     },
     "ui/drawer": {
       "name": "@washingtonpost/wpds-drawer",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-focus-scope": "^1.0.0",
         "@washingtonpost/wpds-assets": "^1.18.0",
-        "@washingtonpost/wpds-button": "1.7.1",
-        "@washingtonpost/wpds-icon": "1.7.1",
-        "@washingtonpost/wpds-scrim": "1.7.1",
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-button": "1.8.0",
+        "@washingtonpost/wpds-icon": "1.8.0",
+        "@washingtonpost/wpds-scrim": "1.8.0",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "react-transition-group": "^4.4.5"
       },
       "devDependencies": {
@@ -49303,10 +49303,10 @@
     },
     "ui/error-message": {
       "name": "@washingtonpost/wpds-error-message",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.7.1"
+        "@washingtonpost/wpds-theme": "1.8.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -49319,10 +49319,10 @@
     },
     "ui/eslint-plugin": {
       "name": "@washingtonpost/eslint-plugin-wpds",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.7.1"
+        "@washingtonpost/wpds-theme": "1.8.0"
       },
       "devDependencies": {
         "jest": "^28.1.0"
@@ -50239,10 +50239,10 @@
     },
     "ui/fieldset": {
       "name": "@washingtonpost/wpds-fieldset",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.7.1"
+        "@washingtonpost/wpds-theme": "1.8.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -50255,10 +50255,10 @@
     },
     "ui/helper-text": {
       "name": "@washingtonpost/wpds-helper-text",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.7.1"
+        "@washingtonpost/wpds-theme": "1.8.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -50271,11 +50271,11 @@
     },
     "ui/icon": {
       "name": "@washingtonpost/wpds-icon",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.7.1",
-        "@washingtonpost/wpds-visually-hidden": "1.7.1",
+        "@washingtonpost/wpds-theme": "1.8.0",
+        "@washingtonpost/wpds-visually-hidden": "1.8.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {
@@ -50290,12 +50290,12 @@
     },
     "ui/input-label": {
       "name": "@washingtonpost/wpds-input-label",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-label": "^1.0.0",
-        "@washingtonpost/wpds-input-shared": "1.7.1",
-        "@washingtonpost/wpds-theme": "1.7.1"
+        "@washingtonpost/wpds-input-shared": "1.8.0",
+        "@washingtonpost/wpds-theme": "1.8.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -50309,12 +50309,12 @@
     },
     "ui/input-password": {
       "name": "@washingtonpost/wpds-input-password",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@washingtonpost/wpds-assets": "^1.18.0",
-        "@washingtonpost/wpds-icon": "1.7.1",
-        "@washingtonpost/wpds-input-text": "1.7.1"
+        "@washingtonpost/wpds-icon": "1.8.0",
+        "@washingtonpost/wpds-input-text": "1.8.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -50341,15 +50341,15 @@
     },
     "ui/input-search": {
       "name": "@washingtonpost/wpds-input-search",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@reach/combobox": "^0.18.0",
         "@washingtonpost/wpds-assets": "^1.18.0",
-        "@washingtonpost/wpds-icon": "1.7.1",
-        "@washingtonpost/wpds-input-label": "1.7.1",
-        "@washingtonpost/wpds-input-text": "1.7.1",
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-icon": "1.8.0",
+        "@washingtonpost/wpds-input-label": "1.8.0",
+        "@washingtonpost/wpds-input-text": "1.8.0",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "match-sorter": "6.3.1"
       },
       "devDependencies": {
@@ -50367,10 +50367,10 @@
     },
     "ui/input-shared": {
       "name": "@washingtonpost/wpds-input-shared",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.7.1"
+        "@washingtonpost/wpds-theme": "1.8.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -50383,20 +50383,20 @@
     },
     "ui/input-text": {
       "name": "@washingtonpost/wpds-input-text",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-label": "^1.0.0",
         "@washingtonpost/wpds-assets": "^1.18.0",
-        "@washingtonpost/wpds-box": "1.7.1",
-        "@washingtonpost/wpds-button": "1.7.1",
-        "@washingtonpost/wpds-error-message": "1.7.1",
-        "@washingtonpost/wpds-helper-text": "1.7.1",
-        "@washingtonpost/wpds-icon": "1.7.1",
-        "@washingtonpost/wpds-input-label": "1.7.1",
-        "@washingtonpost/wpds-input-shared": "1.7.1",
-        "@washingtonpost/wpds-theme": "1.7.1",
-        "@washingtonpost/wpds-visually-hidden": "1.7.1",
+        "@washingtonpost/wpds-box": "1.8.0",
+        "@washingtonpost/wpds-button": "1.8.0",
+        "@washingtonpost/wpds-error-message": "1.8.0",
+        "@washingtonpost/wpds-helper-text": "1.8.0",
+        "@washingtonpost/wpds-icon": "1.8.0",
+        "@washingtonpost/wpds-input-label": "1.8.0",
+        "@washingtonpost/wpds-input-shared": "1.8.0",
+        "@washingtonpost/wpds-theme": "1.8.0",
+        "@washingtonpost/wpds-visually-hidden": "1.8.0",
         "nanoid": "^3.3.4"
       },
       "devDependencies": {
@@ -50442,14 +50442,14 @@
     },
     "ui/input-textarea": {
       "name": "@washingtonpost/wpds-input-textarea",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-error-message": "1.7.1",
-        "@washingtonpost/wpds-helper-text": "1.7.1",
-        "@washingtonpost/wpds-input-label": "1.7.1",
-        "@washingtonpost/wpds-input-shared": "1.7.1",
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-error-message": "1.8.0",
+        "@washingtonpost/wpds-helper-text": "1.8.0",
+        "@washingtonpost/wpds-input-label": "1.8.0",
+        "@washingtonpost/wpds-input-shared": "1.8.0",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "nanoid": "^3.3.4",
         "react": "^16.8.6 || ^17.0.2"
       },
@@ -50468,43 +50468,43 @@
     },
     "ui/kit": {
       "name": "@washingtonpost/wpds-ui-kit",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/eslint-plugin-wpds": "1.7.1",
-        "@washingtonpost/wpds-accordion": "1.7.1",
-        "@washingtonpost/wpds-alert-banner": "1.7.1",
-        "@washingtonpost/wpds-app-bar": "1.7.1",
-        "@washingtonpost/wpds-avatar": "1.7.1",
-        "@washingtonpost/wpds-box": "1.7.1",
-        "@washingtonpost/wpds-button": "1.7.1",
-        "@washingtonpost/wpds-card": "1.7.1",
-        "@washingtonpost/wpds-carousel": "1.7.1",
-        "@washingtonpost/wpds-checkbox": "1.7.1",
-        "@washingtonpost/wpds-container": "1.7.1",
-        "@washingtonpost/wpds-divider": "1.7.1",
-        "@washingtonpost/wpds-drawer": "1.7.1",
-        "@washingtonpost/wpds-error-message": "1.7.1",
-        "@washingtonpost/wpds-fieldset": "1.7.1",
-        "@washingtonpost/wpds-helper-text": "1.7.1",
-        "@washingtonpost/wpds-icon": "1.7.1",
-        "@washingtonpost/wpds-input-label": "1.7.1",
-        "@washingtonpost/wpds-input-password": "1.7.1",
-        "@washingtonpost/wpds-input-search": "1.7.1",
-        "@washingtonpost/wpds-input-shared": "1.7.1",
-        "@washingtonpost/wpds-input-text": "1.7.1",
-        "@washingtonpost/wpds-input-textarea": "1.7.1",
-        "@washingtonpost/wpds-navigation-menu": "1.7.1",
-        "@washingtonpost/wpds-pagination-dots": "1.7.1",
-        "@washingtonpost/wpds-popover": "1.7.1",
-        "@washingtonpost/wpds-radio-group": "1.7.1",
-        "@washingtonpost/wpds-scrim": "1.7.1",
-        "@washingtonpost/wpds-select": "1.7.1",
-        "@washingtonpost/wpds-switch": "1.7.1",
-        "@washingtonpost/wpds-tabs": "1.7.1",
-        "@washingtonpost/wpds-theme": "1.7.1",
-        "@washingtonpost/wpds-tooltip": "1.7.1",
-        "@washingtonpost/wpds-visually-hidden": "1.7.1"
+        "@washingtonpost/eslint-plugin-wpds": "1.8.0",
+        "@washingtonpost/wpds-accordion": "1.8.0",
+        "@washingtonpost/wpds-alert-banner": "1.8.0",
+        "@washingtonpost/wpds-app-bar": "1.8.0",
+        "@washingtonpost/wpds-avatar": "1.8.0",
+        "@washingtonpost/wpds-box": "1.8.0",
+        "@washingtonpost/wpds-button": "1.8.0",
+        "@washingtonpost/wpds-card": "1.8.0",
+        "@washingtonpost/wpds-carousel": "1.8.0",
+        "@washingtonpost/wpds-checkbox": "1.8.0",
+        "@washingtonpost/wpds-container": "1.8.0",
+        "@washingtonpost/wpds-divider": "1.8.0",
+        "@washingtonpost/wpds-drawer": "1.8.0",
+        "@washingtonpost/wpds-error-message": "1.8.0",
+        "@washingtonpost/wpds-fieldset": "1.8.0",
+        "@washingtonpost/wpds-helper-text": "1.8.0",
+        "@washingtonpost/wpds-icon": "1.8.0",
+        "@washingtonpost/wpds-input-label": "1.8.0",
+        "@washingtonpost/wpds-input-password": "1.8.0",
+        "@washingtonpost/wpds-input-search": "1.8.0",
+        "@washingtonpost/wpds-input-shared": "1.8.0",
+        "@washingtonpost/wpds-input-text": "1.8.0",
+        "@washingtonpost/wpds-input-textarea": "1.8.0",
+        "@washingtonpost/wpds-navigation-menu": "1.8.0",
+        "@washingtonpost/wpds-pagination-dots": "1.8.0",
+        "@washingtonpost/wpds-popover": "1.8.0",
+        "@washingtonpost/wpds-radio-group": "1.8.0",
+        "@washingtonpost/wpds-scrim": "1.8.0",
+        "@washingtonpost/wpds-select": "1.8.0",
+        "@washingtonpost/wpds-switch": "1.8.0",
+        "@washingtonpost/wpds-tabs": "1.8.0",
+        "@washingtonpost/wpds-theme": "1.8.0",
+        "@washingtonpost/wpds-tooltip": "1.8.0",
+        "@washingtonpost/wpds-visually-hidden": "1.8.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -50549,11 +50549,11 @@
     },
     "ui/kitchen-sink": {
       "name": "@washingtonpost/wpds-kitchen-sink",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@washingtonpost/wpds-assets": "latest",
-        "@washingtonpost/wpds-ui-kit": "1.7.1",
+        "@washingtonpost/wpds-ui-kit": "1.8.0",
         "nanoid": "^3.3.4"
       },
       "devDependencies": {
@@ -50581,12 +50581,12 @@
     },
     "ui/navigation-menu": {
       "name": "@washingtonpost/wpds-navigation-menu",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.7",
         "@radix-ui/react-navigation-menu": "^1.1.2",
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "popper-max-size-modifier": "^0.2.0",
         "react-popper": "^2.3.0",
         "react-transition-group": "^4.4.5"
@@ -50602,10 +50602,10 @@
     },
     "ui/pagination-dots": {
       "name": "@washingtonpost/wpds-pagination-dots",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.7.1"
+        "@washingtonpost/wpds-theme": "1.8.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -50618,14 +50618,14 @@
     },
     "ui/popover": {
       "name": "@washingtonpost/wpds-popover",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-popover": "^1.0.2",
         "@washingtonpost/wpds-assets": "^1.18.0",
-        "@washingtonpost/wpds-button": "1.7.1",
-        "@washingtonpost/wpds-icon": "1.7.1",
-        "@washingtonpost/wpds-theme": "1.7.1"
+        "@washingtonpost/wpds-button": "1.8.0",
+        "@washingtonpost/wpds-icon": "1.8.0",
+        "@washingtonpost/wpds-theme": "1.8.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -50638,14 +50638,14 @@
     },
     "ui/radio-group": {
       "name": "@washingtonpost/wpds-radio-group",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-radio-group": "^1.0.0",
-        "@washingtonpost/wpds-error-message": "1.7.1",
-        "@washingtonpost/wpds-fieldset": "1.7.1",
-        "@washingtonpost/wpds-input-label": "1.7.1",
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-error-message": "1.8.0",
+        "@washingtonpost/wpds-fieldset": "1.8.0",
+        "@washingtonpost/wpds-input-label": "1.8.0",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "nanoid": "^3.3.3"
       },
       "devDependencies": {
@@ -50741,11 +50741,11 @@
     },
     "ui/scrim": {
       "name": "@washingtonpost/wpds-scrim",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.0.0",
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "react-transition-group": "^4.4.5"
       },
       "devDependencies": {
@@ -50787,17 +50787,17 @@
     },
     "ui/select": {
       "name": "@washingtonpost/wpds-select",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-select": "^1.0.0",
         "@radix-ui/react-use-controllable-state": "^1.0.0",
         "@washingtonpost/wpds-assets": "^1.18.0",
-        "@washingtonpost/wpds-divider": "1.7.1",
-        "@washingtonpost/wpds-icon": "1.7.1",
-        "@washingtonpost/wpds-input-label": "1.7.1",
-        "@washingtonpost/wpds-input-shared": "1.7.1",
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-divider": "1.8.0",
+        "@washingtonpost/wpds-icon": "1.8.0",
+        "@washingtonpost/wpds-input-label": "1.8.0",
+        "@washingtonpost/wpds-input-shared": "1.8.0",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "nanoid": "^3.3.4"
       },
       "devDependencies": {
@@ -50818,11 +50818,11 @@
     },
     "ui/switch": {
       "name": "@washingtonpost/wpds-switch",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-switch": "^1.0.1",
-        "@washingtonpost/wpds-theme": "1.7.1"
+        "@washingtonpost/wpds-theme": "1.8.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -50835,15 +50835,15 @@
     },
     "ui/tabs": {
       "name": "@washingtonpost/wpds-tabs",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "^1.0.2",
         "@radix-ui/react-tabs": "latest",
         "@washingtonpost/wpds-assets": "^1.16.0",
         "@washingtonpost/wpds-icon": "1.1.0",
-        "@washingtonpost/wpds-theme": "1.7.1",
-        "@washingtonpost/wpds-tooltip": "1.7.1",
+        "@washingtonpost/wpds-theme": "1.8.0",
+        "@washingtonpost/wpds-tooltip": "1.8.0",
         "react-transition-group": "^4.4.5"
       },
       "devDependencies": {
@@ -51111,10 +51111,10 @@
     },
     "ui/tailwind-theme": {
       "name": "@washingtonpost/wpds-tailwind-theme",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.7.1"
+        "@washingtonpost/wpds-theme": "1.8.0"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.14",
@@ -51668,7 +51668,7 @@
     },
     "ui/theme": {
       "name": "@washingtonpost/wpds-theme",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@stitches/react": "^1.2.8"
@@ -51680,11 +51680,11 @@
     },
     "ui/tooltip": {
       "name": "@washingtonpost/wpds-tooltip",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-tooltip": "^1.0.0",
-        "@washingtonpost/wpds-theme": "1.7.1"
+        "@washingtonpost/wpds-theme": "1.8.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -51698,10 +51698,10 @@
     },
     "ui/visually-hidden": {
       "name": "@washingtonpost/wpds-visually-hidden",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {
@@ -63095,7 +63095,7 @@
     "@washingtonpost/eslint-plugin-wpds": {
       "version": "file:ui/eslint-plugin",
       "requires": {
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "jest": "^28.1.0"
       },
       "dependencies": {
@@ -63774,8 +63774,8 @@
       "requires": {
         "@radix-ui/react-accordion": "latest",
         "@washingtonpost/wpds-assets": "^1.18.0",
-        "@washingtonpost/wpds-icon": "1.7.1",
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-icon": "1.8.0",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "tsup": "5.11.13",
         "typescript": "4.5.5"
       },
@@ -63838,12 +63838,12 @@
     "@washingtonpost/wpds-alert-banner": {
       "version": "file:ui/alert-banner",
       "requires": {
-        "@washingtonpost/wpds-app-bar": "1.7.1",
+        "@washingtonpost/wpds-app-bar": "1.8.0",
         "@washingtonpost/wpds-assets": "^1.18.0",
-        "@washingtonpost/wpds-button": "1.7.1",
-        "@washingtonpost/wpds-container": "1.7.1",
-        "@washingtonpost/wpds-icon": "1.7.1",
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-button": "1.8.0",
+        "@washingtonpost/wpds-container": "1.8.0",
+        "@washingtonpost/wpds-icon": "1.8.0",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "react": "^16.8.6 || ^17.0.2",
         "tsup": "5.11.13",
         "typescript": "4.5.5"
@@ -63861,7 +63861,7 @@
     "@washingtonpost/wpds-app-bar": {
       "version": "file:ui/app-bar",
       "requires": {
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "react": "^16.8.6 || ^17.0.2",
         "tsup": "5.11.13",
         "typescript": "4.5.5"
@@ -63878,7 +63878,7 @@
       "version": "file:ui/avatar",
       "requires": {
         "@radix-ui/react-avatar": "latest",
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "tsup": "5.11.13",
         "typescript": "4.5.5"
       },
@@ -63900,7 +63900,7 @@
     "@washingtonpost/wpds-box": {
       "version": "file:ui/box",
       "requires": {
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "react": "^16.8.6 || ^17.0.2",
         "tsup": "5.11.13",
         "typescript": "4.5.5"
@@ -63909,7 +63909,7 @@
     "@washingtonpost/wpds-button": {
       "version": "file:ui/button",
       "requires": {
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "react": "^16.8.6 || ^17.0.2",
         "tsup": "5.11.13",
         "typescript": "4.5.5"
@@ -63918,7 +63918,7 @@
     "@washingtonpost/wpds-card": {
       "version": "file:ui/card",
       "requires": {
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "tsup": "5.11.13",
         "typescript": "4.5.5"
       }
@@ -63929,10 +63929,10 @@
         "@radix-ui/react-slot": "^1.0.0",
         "@radix-ui/react-use-controllable-state": "^1.0.0",
         "@washingtonpost/wpds-assets": "^1.18.0",
-        "@washingtonpost/wpds-button": "1.7.1",
-        "@washingtonpost/wpds-icon": "1.7.1",
-        "@washingtonpost/wpds-pagination-dots": "1.7.1",
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-button": "1.8.0",
+        "@washingtonpost/wpds-icon": "1.8.0",
+        "@washingtonpost/wpds-pagination-dots": "1.8.0",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "nanoid": "^3.3.4",
         "react-swipeable": "^7.0.0",
         "tsup": "^5.11.13",
@@ -63944,11 +63944,11 @@
       "requires": {
         "@radix-ui/react-checkbox": "^1.0.0",
         "@washingtonpost/wpds-assets": "^1.18.0",
-        "@washingtonpost/wpds-icon": "1.7.1",
-        "@washingtonpost/wpds-input-label": "1.7.1",
-        "@washingtonpost/wpds-input-shared": "1.7.1",
-        "@washingtonpost/wpds-theme": "1.7.1",
-        "@washingtonpost/wpds-visually-hidden": "1.7.1",
+        "@washingtonpost/wpds-icon": "1.8.0",
+        "@washingtonpost/wpds-input-label": "1.8.0",
+        "@washingtonpost/wpds-input-shared": "1.8.0",
+        "@washingtonpost/wpds-theme": "1.8.0",
+        "@washingtonpost/wpds-visually-hidden": "1.8.0",
         "react": "^16.8.6 || ^17.0.2",
         "tsup": "5.11.13",
         "typescript": "4.5.5"
@@ -63994,7 +63994,7 @@
     "@washingtonpost/wpds-container": {
       "version": "file:ui/container",
       "requires": {
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "react": "^16.8.6 || ^17.0.2",
         "tsup": "5.11.13",
         "typescript": "4.5.5"
@@ -64004,7 +64004,7 @@
       "version": "file:ui/divider",
       "requires": {
         "@radix-ui/react-separator": "^1.0.0",
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "tsup": "5.11.13",
         "typescript": "4.5.5"
       },
@@ -64043,11 +64043,11 @@
         "@types/react": "^17.0.38",
         "@washingtonpost/site-favicons": "^0.1.3",
         "@washingtonpost/tachyons-css": "^1.8.0",
-        "@washingtonpost/wpds-accordion": "1.7.1",
+        "@washingtonpost/wpds-accordion": "1.8.0",
         "@washingtonpost/wpds-assets": "1.20.0",
-        "@washingtonpost/wpds-kitchen-sink": "1.7.1",
-        "@washingtonpost/wpds-tailwind-theme": "1.7.1",
-        "@washingtonpost/wpds-ui-kit": "1.7.1",
+        "@washingtonpost/wpds-kitchen-sink": "1.8.0",
+        "@washingtonpost/wpds-tailwind-theme": "1.8.0",
+        "@washingtonpost/wpds-ui-kit": "1.8.0",
         "autoprefixer": "^10.4.13",
         "babel-plugin-extract-react-types": "^0.1.14",
         "eslint": "8.6.0",
@@ -64446,10 +64446,10 @@
       "requires": {
         "@radix-ui/react-focus-scope": "^1.0.0",
         "@washingtonpost/wpds-assets": "^1.18.0",
-        "@washingtonpost/wpds-button": "1.7.1",
-        "@washingtonpost/wpds-icon": "1.7.1",
-        "@washingtonpost/wpds-scrim": "1.7.1",
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-button": "1.8.0",
+        "@washingtonpost/wpds-icon": "1.8.0",
+        "@washingtonpost/wpds-scrim": "1.8.0",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "react-transition-group": "^4.4.5",
         "tsup": "5.11.13",
         "typescript": "4.5.5"
@@ -64467,7 +64467,7 @@
     "@washingtonpost/wpds-error-message": {
       "version": "file:ui/error-message",
       "requires": {
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "tsup": "5.11.13",
         "typescript": "4.5.5"
       }
@@ -64475,7 +64475,7 @@
     "@washingtonpost/wpds-fieldset": {
       "version": "file:ui/fieldset",
       "requires": {
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "tsup": "5.11.13",
         "typescript": "4.5.5"
       }
@@ -64483,7 +64483,7 @@
     "@washingtonpost/wpds-helper-text": {
       "version": "file:ui/helper-text",
       "requires": {
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "tsup": "5.11.13",
         "typescript": "4.5.5"
       }
@@ -64491,8 +64491,8 @@
     "@washingtonpost/wpds-icon": {
       "version": "file:ui/icon",
       "requires": {
-        "@washingtonpost/wpds-theme": "1.7.1",
-        "@washingtonpost/wpds-visually-hidden": "1.7.1",
+        "@washingtonpost/wpds-theme": "1.8.0",
+        "@washingtonpost/wpds-visually-hidden": "1.8.0",
         "react": "^16.8.6 || ^17.0.2",
         "tsup": "5.11.13",
         "typescript": "4.5.5"
@@ -64502,8 +64502,8 @@
       "version": "file:ui/input-label",
       "requires": {
         "@radix-ui/react-label": "^1.0.0",
-        "@washingtonpost/wpds-input-shared": "1.7.1",
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-input-shared": "1.8.0",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "tsup": "5.11.13",
         "typescript": "4.5.5"
       }
@@ -64512,8 +64512,8 @@
       "version": "file:ui/input-password",
       "requires": {
         "@washingtonpost/wpds-assets": "^1.18.0",
-        "@washingtonpost/wpds-icon": "1.7.1",
-        "@washingtonpost/wpds-input-text": "1.7.1",
+        "@washingtonpost/wpds-icon": "1.8.0",
+        "@washingtonpost/wpds-input-text": "1.8.0",
         "tsup": "5.11.13",
         "typescript": "4.5.5"
       },
@@ -64532,10 +64532,10 @@
       "requires": {
         "@reach/combobox": "^0.18.0",
         "@washingtonpost/wpds-assets": "^1.18.0",
-        "@washingtonpost/wpds-icon": "1.7.1",
-        "@washingtonpost/wpds-input-label": "1.7.1",
-        "@washingtonpost/wpds-input-text": "1.7.1",
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-icon": "1.8.0",
+        "@washingtonpost/wpds-input-label": "1.8.0",
+        "@washingtonpost/wpds-input-text": "1.8.0",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "match-sorter": "6.3.1",
         "tsup": "5.11.13",
         "typescript": "4.5.5"
@@ -64544,7 +64544,7 @@
     "@washingtonpost/wpds-input-shared": {
       "version": "file:ui/input-shared",
       "requires": {
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "tsup": "5.11.13",
         "typescript": "4.5.5"
       }
@@ -64554,15 +64554,15 @@
       "requires": {
         "@radix-ui/react-label": "^1.0.0",
         "@washingtonpost/wpds-assets": "^1.18.0",
-        "@washingtonpost/wpds-box": "1.7.1",
-        "@washingtonpost/wpds-button": "1.7.1",
-        "@washingtonpost/wpds-error-message": "1.7.1",
-        "@washingtonpost/wpds-helper-text": "1.7.1",
-        "@washingtonpost/wpds-icon": "1.7.1",
-        "@washingtonpost/wpds-input-label": "1.7.1",
-        "@washingtonpost/wpds-input-shared": "1.7.1",
-        "@washingtonpost/wpds-theme": "1.7.1",
-        "@washingtonpost/wpds-visually-hidden": "1.7.1",
+        "@washingtonpost/wpds-box": "1.8.0",
+        "@washingtonpost/wpds-button": "1.8.0",
+        "@washingtonpost/wpds-error-message": "1.8.0",
+        "@washingtonpost/wpds-helper-text": "1.8.0",
+        "@washingtonpost/wpds-icon": "1.8.0",
+        "@washingtonpost/wpds-input-label": "1.8.0",
+        "@washingtonpost/wpds-input-shared": "1.8.0",
+        "@washingtonpost/wpds-theme": "1.8.0",
+        "@washingtonpost/wpds-visually-hidden": "1.8.0",
         "nanoid": "^3.3.4",
         "tsup": "5.11.13",
         "typescript": "4.5.5"
@@ -64583,11 +64583,11 @@
     "@washingtonpost/wpds-input-textarea": {
       "version": "file:ui/input-textarea",
       "requires": {
-        "@washingtonpost/wpds-error-message": "1.7.1",
-        "@washingtonpost/wpds-helper-text": "1.7.1",
-        "@washingtonpost/wpds-input-label": "1.7.1",
-        "@washingtonpost/wpds-input-shared": "1.7.1",
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-error-message": "1.8.0",
+        "@washingtonpost/wpds-helper-text": "1.8.0",
+        "@washingtonpost/wpds-input-label": "1.8.0",
+        "@washingtonpost/wpds-input-shared": "1.8.0",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "nanoid": "^3.3.4",
         "react": "^16.8.6 || ^17.0.2",
         "tsup": "5.11.13",
@@ -64598,7 +64598,7 @@
       "version": "file:ui/kitchen-sink",
       "requires": {
         "@washingtonpost/wpds-assets": "latest",
-        "@washingtonpost/wpds-ui-kit": "1.7.1",
+        "@washingtonpost/wpds-ui-kit": "1.8.0",
         "nanoid": "^3.3.4",
         "tsup": "5.11.13",
         "typescript": "4.5.5"
@@ -64620,7 +64620,7 @@
       "requires": {
         "@popperjs/core": "^2.11.7",
         "@radix-ui/react-navigation-menu": "^1.1.2",
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "popper-max-size-modifier": "^0.2.0",
         "react-popper": "^2.3.0",
         "react-transition-group": "^4.4.5",
@@ -64631,7 +64631,7 @@
     "@washingtonpost/wpds-pagination-dots": {
       "version": "file:ui/pagination-dots",
       "requires": {
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "tsup": "5.11.13",
         "typescript": "4.5.5"
       }
@@ -64641,9 +64641,9 @@
       "requires": {
         "@radix-ui/react-popover": "^1.0.2",
         "@washingtonpost/wpds-assets": "^1.18.0",
-        "@washingtonpost/wpds-button": "1.7.1",
-        "@washingtonpost/wpds-icon": "1.7.1",
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-button": "1.8.0",
+        "@washingtonpost/wpds-icon": "1.8.0",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "tsup": "5.11.13",
         "typescript": "4.5.5"
       }
@@ -64652,10 +64652,10 @@
       "version": "file:ui/radio-group",
       "requires": {
         "@radix-ui/react-radio-group": "^1.0.0",
-        "@washingtonpost/wpds-error-message": "1.7.1",
-        "@washingtonpost/wpds-fieldset": "1.7.1",
-        "@washingtonpost/wpds-input-label": "1.7.1",
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-error-message": "1.8.0",
+        "@washingtonpost/wpds-fieldset": "1.8.0",
+        "@washingtonpost/wpds-input-label": "1.8.0",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "nanoid": "^3.3.3",
         "tsup": "5.11.13",
         "typescript": "4.5.5"
@@ -64722,7 +64722,7 @@
       "version": "file:ui/scrim",
       "requires": {
         "@radix-ui/react-dialog": "^1.0.0",
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "react-transition-group": "^4.4.5",
         "tsup": "5.11.13",
         "typescript": "4.5.5"
@@ -64734,11 +64734,11 @@
         "@radix-ui/react-select": "^1.0.0",
         "@radix-ui/react-use-controllable-state": "^1.0.0",
         "@washingtonpost/wpds-assets": "^1.18.0",
-        "@washingtonpost/wpds-divider": "1.7.1",
-        "@washingtonpost/wpds-icon": "1.7.1",
-        "@washingtonpost/wpds-input-label": "1.7.1",
-        "@washingtonpost/wpds-input-shared": "1.7.1",
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-divider": "1.8.0",
+        "@washingtonpost/wpds-icon": "1.8.0",
+        "@washingtonpost/wpds-input-label": "1.8.0",
+        "@washingtonpost/wpds-input-shared": "1.8.0",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "nanoid": "^3.3.4",
         "tsup": "5.11.13",
         "typescript": "4.5.5"
@@ -64748,7 +64748,7 @@
       "version": "file:ui/switch",
       "requires": {
         "@radix-ui/react-switch": "^1.0.1",
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "tsup": "5.11.13",
         "typescript": "4.5.5"
       }
@@ -64760,8 +64760,8 @@
         "@radix-ui/react-tabs": "latest",
         "@washingtonpost/wpds-assets": "^1.16.0",
         "@washingtonpost/wpds-icon": "1.1.0",
-        "@washingtonpost/wpds-theme": "1.7.1",
-        "@washingtonpost/wpds-tooltip": "1.7.1",
+        "@washingtonpost/wpds-theme": "1.8.0",
+        "@washingtonpost/wpds-tooltip": "1.8.0",
         "react-transition-group": "^4.4.5",
         "tsup": "^5.11.13",
         "typescript": "4.5.5"
@@ -64913,7 +64913,7 @@
     "@washingtonpost/wpds-tailwind-theme": {
       "version": "file:ui/tailwind-theme",
       "requires": {
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "autoprefixer": "^10.4.14",
         "postcss": "^8.4.24",
         "tailwindcss": "^3.3.2",
@@ -65176,7 +65176,7 @@
       "version": "file:ui/tooltip",
       "requires": {
         "@radix-ui/react-tooltip": "^1.0.0",
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "tsup": "5.11.13",
         "typescript": "4.5.5"
       }
@@ -65184,40 +65184,40 @@
     "@washingtonpost/wpds-ui-kit": {
       "version": "file:ui/kit",
       "requires": {
-        "@washingtonpost/eslint-plugin-wpds": "1.7.1",
-        "@washingtonpost/wpds-accordion": "1.7.1",
-        "@washingtonpost/wpds-alert-banner": "1.7.1",
-        "@washingtonpost/wpds-app-bar": "1.7.1",
-        "@washingtonpost/wpds-avatar": "1.7.1",
-        "@washingtonpost/wpds-box": "1.7.1",
-        "@washingtonpost/wpds-button": "1.7.1",
-        "@washingtonpost/wpds-card": "1.7.1",
-        "@washingtonpost/wpds-carousel": "1.7.1",
-        "@washingtonpost/wpds-checkbox": "1.7.1",
-        "@washingtonpost/wpds-container": "1.7.1",
-        "@washingtonpost/wpds-divider": "1.7.1",
-        "@washingtonpost/wpds-drawer": "1.7.1",
-        "@washingtonpost/wpds-error-message": "1.7.1",
-        "@washingtonpost/wpds-fieldset": "1.7.1",
-        "@washingtonpost/wpds-helper-text": "1.7.1",
-        "@washingtonpost/wpds-icon": "1.7.1",
-        "@washingtonpost/wpds-input-label": "1.7.1",
-        "@washingtonpost/wpds-input-password": "1.7.1",
-        "@washingtonpost/wpds-input-search": "1.7.1",
-        "@washingtonpost/wpds-input-shared": "1.7.1",
-        "@washingtonpost/wpds-input-text": "1.7.1",
-        "@washingtonpost/wpds-input-textarea": "1.7.1",
-        "@washingtonpost/wpds-navigation-menu": "1.7.1",
-        "@washingtonpost/wpds-pagination-dots": "1.7.1",
-        "@washingtonpost/wpds-popover": "1.7.1",
-        "@washingtonpost/wpds-radio-group": "1.7.1",
-        "@washingtonpost/wpds-scrim": "1.7.1",
-        "@washingtonpost/wpds-select": "1.7.1",
-        "@washingtonpost/wpds-switch": "1.7.1",
-        "@washingtonpost/wpds-tabs": "1.7.1",
-        "@washingtonpost/wpds-theme": "1.7.1",
-        "@washingtonpost/wpds-tooltip": "1.7.1",
-        "@washingtonpost/wpds-visually-hidden": "1.7.1",
+        "@washingtonpost/eslint-plugin-wpds": "1.8.0",
+        "@washingtonpost/wpds-accordion": "1.8.0",
+        "@washingtonpost/wpds-alert-banner": "1.8.0",
+        "@washingtonpost/wpds-app-bar": "1.8.0",
+        "@washingtonpost/wpds-avatar": "1.8.0",
+        "@washingtonpost/wpds-box": "1.8.0",
+        "@washingtonpost/wpds-button": "1.8.0",
+        "@washingtonpost/wpds-card": "1.8.0",
+        "@washingtonpost/wpds-carousel": "1.8.0",
+        "@washingtonpost/wpds-checkbox": "1.8.0",
+        "@washingtonpost/wpds-container": "1.8.0",
+        "@washingtonpost/wpds-divider": "1.8.0",
+        "@washingtonpost/wpds-drawer": "1.8.0",
+        "@washingtonpost/wpds-error-message": "1.8.0",
+        "@washingtonpost/wpds-fieldset": "1.8.0",
+        "@washingtonpost/wpds-helper-text": "1.8.0",
+        "@washingtonpost/wpds-icon": "1.8.0",
+        "@washingtonpost/wpds-input-label": "1.8.0",
+        "@washingtonpost/wpds-input-password": "1.8.0",
+        "@washingtonpost/wpds-input-search": "1.8.0",
+        "@washingtonpost/wpds-input-shared": "1.8.0",
+        "@washingtonpost/wpds-input-text": "1.8.0",
+        "@washingtonpost/wpds-input-textarea": "1.8.0",
+        "@washingtonpost/wpds-navigation-menu": "1.8.0",
+        "@washingtonpost/wpds-pagination-dots": "1.8.0",
+        "@washingtonpost/wpds-popover": "1.8.0",
+        "@washingtonpost/wpds-radio-group": "1.8.0",
+        "@washingtonpost/wpds-scrim": "1.8.0",
+        "@washingtonpost/wpds-select": "1.8.0",
+        "@washingtonpost/wpds-switch": "1.8.0",
+        "@washingtonpost/wpds-tabs": "1.8.0",
+        "@washingtonpost/wpds-theme": "1.8.0",
+        "@washingtonpost/wpds-tooltip": "1.8.0",
+        "@washingtonpost/wpds-visually-hidden": "1.8.0",
         "tsup": "5.11.13",
         "typescript": "4.5.5"
       }
@@ -65225,7 +65225,7 @@
     "@washingtonpost/wpds-visually-hidden": {
       "version": "file:ui/visually-hidden",
       "requires": {
-        "@washingtonpost/wpds-theme": "1.7.1",
+        "@washingtonpost/wpds-theme": "1.8.0",
         "react": "^16.8.6 || ^17.0.2",
         "tsup": "5.11.13",
         "typescript": "4.5.5"
@@ -84935,8 +84935,8 @@
         "@types/react": "^18.0.27",
         "@types/react-dom": "^18.0.10",
         "@vitejs/plugin-react": "^3.1.0",
-        "@washingtonpost/wpds-kitchen-sink": "1.7.1",
-        "@washingtonpost/wpds-ui-kit": "1.7.1",
+        "@washingtonpost/wpds-kitchen-sink": "1.8.0",
+        "@washingtonpost/wpds-ui-kit": "1.8.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "vite": "^4.1.0"
@@ -84995,8 +84995,8 @@
         "@types/react": "^18.0.0",
         "@types/react-dom": "^18.0.0",
         "@vitejs/plugin-react": "^1.3.0",
-        "@washingtonpost/wpds-kitchen-sink": "1.7.1",
-        "@washingtonpost/wpds-ui-kit": "1.7.1",
+        "@washingtonpost/wpds-kitchen-sink": "1.8.0",
+        "@washingtonpost/wpds-ui-kit": "1.8.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "vite": "^2.9.15"


### PR DESCRIPTION
Remove release blocker
