### PR TITLE
fix: type InputText buttons as buttons to prevent form submission

### DIFF
--- a/ui/input-text/src/InputText.tsx
+++ b/ui/input-text/src/InputText.tsx
@@ -84,6 +84,8 @@ export interface InputTextProps
   extends React.ComponentPropsWithRef<typeof UnstyledInput> {
   /** Accessible text for button icon, required for right icons */
   buttonIconText?: string;
+  /** Explicit button icon typing for use in forms */
+  buttonIconType?: "submit" | "reset" | "button";
   /** Used to insert Icons in the input, only a single child is accepted*/
   children?: React.ReactNode;
   /** The initial input element value for uncontrolled components */
@@ -132,6 +134,7 @@ export const InputText = React.forwardRef<HTMLInputElement, InputTextProps>(
   (
     {
       buttonIconText,
+      buttonIconType = "button",
       children,
       defaultValue,
       disabled,
@@ -212,7 +215,7 @@ export const InputText = React.forwardRef<HTMLInputElement, InputTextProps>(
       onButtonIconClick && onButtonIconClick(event);
     };
 
-    const onClear = () => {
+    const onClear = (event) => {
       if (internalRef.current) {
         const input = internalRef.current;
         // requires a native value setter to have the correct value in the dispatched
@@ -360,6 +363,7 @@ export const InputText = React.forwardRef<HTMLInputElement, InputTextProps>(
                   event.preventDefault();
                 }}
                 onClick={onClear}
+                type="button"
               >
                 <VisuallyHidden>Clear</VisuallyHidden>
                 <Icon label={""}>
@@ -381,6 +385,7 @@ export const InputText = React.forwardRef<HTMLInputElement, InputTextProps>(
                   : theme.colors.accessible,
               }}
               onClick={handleButtonIconClick}
+              type={buttonIconType || undefined}
             >
               <VisuallyHidden>{buttonIconText}</VisuallyHidden>
               {child}

--- a/ui/input-text/src/play.stories.tsx
+++ b/ui/input-text/src/play.stories.tsx
@@ -198,6 +198,65 @@ const ChromaticTemplate = () => (
 
 export const Chromatic = ChromaticTemplate.bind({});
 
+const FormTemplate: ComponentStory<typeof Component> = (args) => {
+  const [iconClicked, setIconClicked] = React.useState(false);
+  const [submitClicked, setSubmitClicked] = React.useState(false);
+
+  return (
+    <div>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          setSubmitClicked(true);
+        }}
+      >
+        <Component
+          label="Form test"
+          name="ft"
+          id="ft"
+          type="search"
+          onButtonIconClick={() => {
+            setIconClicked(true);
+          }}
+          buttonIconType={args.buttonIconType}
+        />
+      </form>
+      <div>icon clicked: {iconClicked.toString()}</div>
+      <div>submit clicked: {submitClicked.toString()}</div>
+    </div>
+  );
+};
+
+export const SearchTypeInForm = FormTemplate.bind({});
+
+SearchTypeInForm.args = {
+  buttonIconType: "button",
+};
+
+SearchTypeInForm.parameters = {
+  chromatic: { disableSnapshot: true },
+};
+
+SearchTypeInForm.argTypes = {
+  buttonIconText: { table: { disable: true } },
+  disabled: { table: { disable: true } },
+  error: { table: { disable: true } },
+  label: { table: { disable: true } },
+  icon: { table: { disable: true } },
+  name: { table: { disable: true } },
+  id: { table: { disable: true } },
+  placeholder: { table: { disable: true } },
+  required: { table: { disable: true } },
+  success: { table: { disable: true } },
+  value: { table: { disable: true } },
+  defaultValue: { table: { disable: true } },
+  type: { table: { disable: true } },
+  css: { table: { disable: true } },
+  errorMessage: { table: { disable: true } },
+  helperText: { table: { disable: true } },
+  children: { table: { disable: true } },
+};
+
 const InteractionsTemplate: ComponentStory<typeof Component> = (args) => (
   <Column>
     <Component label="Field 1" name="field-1" id="field-1" />


### PR DESCRIPTION
## What I did

This PR explicitly types the buttons inside of InputSearch as buttons to prevent their onClick events from being called during a form submission triggered by the enter key.

In addition, the ButtonIcon now surfaces a new `type` prop to set as submit if desired.
