### PR TITLE
Add SEO header back in to SEO/Perf guide

### DIFF
--- a/build.washingtonpost.com/docs/resources/guides/performance-and-seo.mdx
+++ b/build.washingtonpost.com/docs/resources/guides/performance-and-seo.mdx
@@ -47,7 +47,7 @@ Web performance and SEO are vital for providing a positive user experience, incr
 
 ## SEO (Search Engine Optimization)
 
-4. On-page SEO:
+1. On-page SEO:
    - Use descriptive and concise title tags to accurately represent the content of each page, helping search engines understand its purpose and relevance.
    - Optimize meta tags for both users and search engines:
      - Write informative and unique `meta description` tags to give users a preview of the page content, improving click-through rates from search results.
@@ -57,11 +57,11 @@ Web performance and SEO are vital for providing a positive user experience, incr
      - Remember, each meta tag serves a distinct purpose, so ensure they are used appropriately and are relevant to the page's content.
    - Use header tags (H1, H2, H3) effectively to structure content and provide hierarchy, making it easier for search engines to understand the content's importance.
    - Optimize URL structures by making them readable, descriptive, and concise, helping both users and search engines understand the page's content.
-5. Content optimization:
+2. Content optimization:
    - Write high-quality, unique, and engaging content to satisfy user intent and increase the likelihood of ranking higher in search results.
    - Use proper keyword targeting by including relevant keywords naturally within the content and avoiding keyword stuffing, which can harm rankings.
    - Optimize images by using descriptive alt text, relevant file names, and compressing images to reduce file sizes, improving page load times.
-6. Technical SEO:
+3. Technical SEO:
    - Improve site speed by optimizing page load times, as faster-loading pages are more likely to rank higher in search results.
    - Implement structured data (schema markup) using JSON-LD to provide additional context for search engines, potentially improving search result appearance and click-through rates. Here are some resources to delve deeper:
      - Understand how to structure data in JSON-LD format. You might use schemas such as `NewsArticle`, `LiveBlogPosting`, and more depending on the content (here is an [example](https://validator.schema.org/#url=https%3A%2F%2Fwww.washingtonpost.com%2Flifestyle%2F2023%2F03%2F15%2Fdog-adoption-potcake-turks-caicos%2F)). Check the JSON-LD website and the Google's guide for further learning.
@@ -70,7 +70,7 @@ Web performance and SEO are vital for providing a positive user experience, incr
    - Ensure crawlability and indexability by properly configuring robots.txt and creating XML sitemaps, helping search engines discover and index the site's content.
    - Use canonical tags to avoid duplicate content issues and signal to search engines which version of a page should be considered the original.
    - Implement HTTPS and secure the site to protect user data and improve trust with both users and search engines.
-7. Off-page SEO:
+4. Off-page SEO:
    - Build high-quality and relevant backlinks from authoritative websites, as they serve as signals of the site's credibility and trustworthiness.
    - Utilize social media for content promotion, expanding the content's reach and potentially attracting more backlinks and organic traffic.
    - Consider guest posting and content outreach to build relationships with other websites and influencers, increasing the site's visibility and authority.

--- a/build.washingtonpost.com/docs/resources/guides/performance-and-seo.mdx
+++ b/build.washingtonpost.com/docs/resources/guides/performance-and-seo.mdx
@@ -42,7 +42,11 @@ Web performance and SEO are vital for providing a positive user experience, incr
    - Use efficient CSS selectors to minimize browser work during the rendering process, and avoid layout thrashing by batching DOM updates and minimizing forced reflows.
    - Optimize JavaScript execution by deferring or asynchronously loading non-critical scripts, profiling and optimizing JavaScript performance, and using requestAnimationFrame for animations.
 3. Responsiveness: - Design websites for various screen sizes and devices to ensure a consistent and enjoyable user experience across different contexts. - Implement responsive design techniques, such as fluid grids, flexible images, CSS Flexbox, and Grid Layout, to create adaptable layouts that adjust to different screen sizes and orientations. - While JavaScript can be used for certain aspects of responsive design, it's generally recommended to prioritize CSS for controlling the layout and visual presentation of the page at different viewport sizes. CSS-based solutions typically perform better, require less code, and can be managed within stylesheets, keeping the separation of concerns between style and functionality. - JavaScript should ideally be used for interactivity and enhancing the user experience, not for managing core layout changes wherever possible. In some complex scenarios, JavaScript might be required to achieve advanced responsive behaviors that CSS alone can't handle. In these cases, care should be taken to ensure performance and accessibility are not negatively impacted.
-   SEO (Search Engine Optimization)
+
+---
+
+## SEO (Search Engine Optimization)
+
 4. On-page SEO:
    - Use descriptive and concise title tags to accurately represent the content of each page, helping search engines understand its purpose and relevance.
    - Optimize meta tags for both users and search engines:


### PR DESCRIPTION
## What I did

I added the SEO header back in to this guide. It seems to have been edited out during the last PR. It just needs to have the double hashtag header and horizontal divider added back into the doc.

<!--
  Explain the **motivation** for making this change. What existing problem does the pull request solve? Please be as detailed as possible.
-->
