### PR TITLE
feat(carousel): use 'left' instead of 'transform' on Slider [WFO-6363]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,11 @@ yalc.lock
 # ignore the storybook build 
 build.washingtonpost.com/public/storybook/**/*
 
+# vim
+*.swp
+*.swo
+*.swn
+
 .env
 .env.*
 .vercel

--- a/ui/carousel/src/CarouselContent.tsx
+++ b/ui/carousel/src/CarouselContent.tsx
@@ -20,11 +20,12 @@ const Container = styled("div", {
 });
 
 const Slider = styled("ul", {
+  position: "relative",
   display: "flex",
   listStyle: "none",
   paddingInlineStart: 0,
   marginBlock: 0,
-  transition: `transform 0.5s ${theme.transitions.inOut}`,
+  transition: `left 0.5s ${theme.transitions.inOut}`,
   "@reducedMotion": {
     transition: "none",
   },
@@ -238,7 +239,7 @@ export const CarouselContent = React.forwardRef<
         role="group"
         aria-activedescendant={props["aria-activedescendant"] || activeId}
       >
-        <Slider css={{ transform: `translateX(${xPos}px)` }}>
+        <Slider css={{ left: `${xPos}px` }}>
           {React.Children.map(children, (child, index) => {
             if (React.isValidElement(child)) {
               return React.cloneElement(


### PR DESCRIPTION
## What I did

We are trying to integrate the WPDS Carousel into Assembler. One use case is a so-called Audio carousel where you can play audio in a "sticky" player. That player is supposed to appear at the bottom right of the viewport and uses `position: "fixed"` to achieve that.

However, [quoting this website](https://developer.mozilla.org/en-US/docs/Web/CSS/position#fixed_positioning):

> Fixed positioning is similar to absolute positioning, with the exception that the element's containing block is the initial containing block established by the viewport, unless any ancestor has `transform`, `perspective`, or `filter` property set to something other than none

The Slider in the WPDS Carousel uses the `transform` property and therefore becomes the base for fixed positioning and leads the sticky player to appear within the carousel.

You can see the undesirable behavior if you click on one of "Listen" text in the Audio carousel -- powered by the current WPD Carousel -- [at the top of this page](https://assembler-git-wfo-6363-wpds-carousel.preview.now.washingtonpost.com/render/carousel-i).

You can see the correct behavior if you click on one of "Listen" text in the Audio carousel -- powered by the Site Component Carousel -- [at the top of this page](https://assembler-git-dev.preview.now.washingtonpost.com/render/carousel-i).

This change is intended to bring the desired behavior to the WPDS Carousel so we can adopt in Assembler.

The Carousel can be [tested in storybook.](https://wpds-ui-kit-storybook-git-fork-wpmedia-main.preview.now.washingtonpost.com/?path=/story/carousel--carousel)