### PR TITLE
fix: remove console logging for InputSearchInput

### DIFF
--- a/ui/input-search/src/InputSearchInput.tsx
+++ b/ui/input-search/src/InputSearchInput.tsx
@@ -27,7 +27,7 @@ export const InputSearchInput = React.forwardRef<
   InputSearchInputProps
 >(({ label = "Search", name, id, ...rest }: InputSearchInputProps, ref) => {
   const { disabled, usePortal } = React.useContext(InputSearchContext);
-  console.log("usePortal", usePortal);
+  // console.log("usePortal", usePortal);
   return (
     <div
       style={


### PR DESCRIPTION
## What I did

I'm using the draft version of the `InputSearchInput` for our [mass killings tracker](https://github.com/WPMedia/int-mass-killings-tracker/blob/new-search-box/components/elements/MassKillingsSearch/Search.tsx#L48-L83), and while I've got it working for our use, I want to comment out the logging that snuck into the 1.9.1 release.