### PR TITLE
chore: update radix accordion version in preparation for node 18 update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -704,7 +704,6 @@
         "@radix-ui/react-accordion": "^1.0.0",
         "@radix-ui/react-checkbox": "^1.0.0",
         "@radix-ui/react-collapsible": "^1.0.0",
-        "@radix-ui/react-select": "^1.2.2",
         "@radix-ui/react-toggle-group": "^1.0.1",
         "@stitches/react": "1.2.8",
         "@washingtonpost/site-favicons": "^0.1.3",
@@ -49302,7 +49301,7 @@
       "version": "1.9.1",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-accordion": "latest",
+        "@radix-ui/react-accordion": "^1.1.0",
         "@washingtonpost/wpds-assets": "^1.18.0",
         "@washingtonpost/wpds-icon": "1.9.1",
         "@washingtonpost/wpds-theme": "1.9.1"
@@ -49312,10 +49311,7 @@
         "typescript": "4.5.5"
       },
       "peerDependencies": {
-        "@radix-ui/react-accordion": "latest",
         "@washingtonpost/wpds-assets": "^1.18.0",
-        "@washingtonpost/wpds-icon": "*",
-        "@washingtonpost/wpds-theme": "*",
         "react": "^16.8.6 || ^17.0.2"
       }
     },
@@ -64453,7 +64449,7 @@
     "@washingtonpost/wpds-accordion": {
       "version": "file:ui/accordion",
       "requires": {
-        "@radix-ui/react-accordion": "latest",
+        "@radix-ui/react-accordion": "^1.1.0",
         "@washingtonpost/wpds-assets": "^1.18.0",
         "@washingtonpost/wpds-icon": "1.9.1",
         "@washingtonpost/wpds-theme": "1.9.1",
@@ -64717,7 +64713,6 @@
         "@radix-ui/react-accordion": "^1.0.0",
         "@radix-ui/react-checkbox": "^1.0.0",
         "@radix-ui/react-collapsible": "^1.0.0",
-        "@radix-ui/react-select": "*",
         "@radix-ui/react-toggle-group": "^1.0.1",
         "@stitches/react": "1.2.8",
         "@types/lz-string": "^1.3.34",

--- a/ui/accordion/package.json
+++ b/ui/accordion/package.json
@@ -36,14 +36,11 @@
     "typescript": "4.5.5"
   },
   "peerDependencies": {
-    "@radix-ui/react-accordion": "latest",
     "@washingtonpost/wpds-assets": "^1.18.0",
-    "@washingtonpost/wpds-icon": "*",
-    "@washingtonpost/wpds-theme": "*",
     "react": "^16.8.6 || ^17.0.2"
   },
   "dependencies": {
-    "@radix-ui/react-accordion": "latest",
+    "@radix-ui/react-accordion": "^1.1.0",
     "@washingtonpost/wpds-assets": "^1.18.0",
     "@washingtonpost/wpds-icon": "1.9.1",
     "@washingtonpost/wpds-theme": "1.9.1"


### PR DESCRIPTION
updating radix accordion version in preparation for node 18 update