### PR TITLE
fix: Simplify Action Menu context

### DIFF
--- a/build.washingtonpost.com/docs/components/action-menu.mdx
+++ b/build.washingtonpost.com/docs/components/action-menu.mdx
@@ -52,14 +52,12 @@ The Action List can be triggered with a button, a link, an icon, or similar visu
         {`Action Button`}
       </Button>
     </ActionMenu.Trigger>
-    <ActionMenu.Portal>
       <ActionMenu.Content>
         <ActionMenu.Item>Action 1</ActionMenu.Item>
         <ActionMenu.Item>Action 2</ActionMenu.Item>
         <ActionMenu.Item>Action 3</ActionMenu.Item>
         <ActionMenu.Item>Action 4</ActionMenu.Item>
       </ActionMenu.Content>
-    </ActionMenu.Portal>
   </ActionMenu.Root>
   <ActionMenu.Root>
     <ActionMenu.Trigger asChild>
@@ -69,14 +67,12 @@ The Action List can be triggered with a button, a link, an icon, or similar visu
         </Icon>
       </Button>
     </ActionMenu.Trigger>
-    <ActionMenu.Portal>
       <ActionMenu.Content>
         <ActionMenu.Item>Action 1</ActionMenu.Item>
         <ActionMenu.Item>Action 2</ActionMenu.Item>
         <ActionMenu.Item>Action 3</ActionMenu.Item>
         <ActionMenu.Item>Action 4</ActionMenu.Item>
       </ActionMenu.Content>
-    </ActionMenu.Portal>
   </ActionMenu.Root>
   <ActionMenu.Root>
     <ActionMenu.Trigger
@@ -85,14 +81,12 @@ The Action List can be triggered with a button, a link, an icon, or similar visu
     >
       <a style={{ marginLeft: "35px", marginRight: "35px" }}>Action Link</a>
     </ActionMenu.Trigger>
-    <ActionMenu.Portal>
       <ActionMenu.Content>
         <ActionMenu.Item>Action 1</ActionMenu.Item>
         <ActionMenu.Item>Action 2</ActionMenu.Item>
         <ActionMenu.Item>Action 3</ActionMenu.Item>
         <ActionMenu.Item>Action 4</ActionMenu.Item>
       </ActionMenu.Content>
-    </ActionMenu.Portal>
   </ActionMenu.Root>
   <ActionMenu.Root>
     <ActionMenu.Trigger asChild>
@@ -100,14 +94,19 @@ The Action List can be triggered with a button, a link, an icon, or similar visu
         <MixerVertical />
       </Icon>
     </ActionMenu.Trigger>
-    <ActionMenu.Portal></ActionMenu.Portal>
+    <ActionMenu.Content>
+      <ActionMenu.Item>Action 1</ActionMenu.Item>
+      <ActionMenu.Item>Action 2</ActionMenu.Item>
+      <ActionMenu.Item>Action 3</ActionMenu.Item>
+      <ActionMenu.Item>Action 4</ActionMenu.Item>
+    </ActionMenu.Content>
   </ActionMenu.Root>
 </Box>
 ```
 
 ### Density
 
-The following options can be applied to `ActionMenu.Content` to specify the density of the items: `default`, `loose`, and `compact`.
+The following options can be applied to specify the density of the items: `default`, `loose`, and `compact`.
 
 ```jsx withPreview
 <Box
@@ -117,45 +116,40 @@ The following options can be applied to `ActionMenu.Content` to specify the dens
     height: "100vh",
   }}
 >
-  <ActionMenu.Root>
+  <ActionMenu.Root density={"default"}>
     <ActionMenu.Trigger asChild>
       <Button css={{ marginLeft: "15px", marginRight: "15px" }}>Default</Button>
     </ActionMenu.Trigger>
-    <ActionMenu.Portal>
-      <ActionMenu.Content density="default" align="end">
-        <ActionMenu.Item>Action 1</ActionMenu.Item>
-        <ActionMenu.Item>Action 2</ActionMenu.Item>
-        <ActionMenu.Item>Action 3</ActionMenu.Item>
-      </ActionMenu.Content>
-    </ActionMenu.Portal>
+    <ActionMenu.Content align="end">
+      <ActionMenu.Item>Action 1</ActionMenu.Item>
+      <ActionMenu.Item>Action 2</ActionMenu.Item>
+      <ActionMenu.Item>Action 3</ActionMenu.Item>
+    </ActionMenu.Content>
   </ActionMenu.Root>
-  <ActionMenu.Root>
+  <ActionMenu.Root density={"loose"}>
     <ActionMenu.Trigger asChild>
       <Button css={{ marginLeft: "15px", marginRight: "15px" }}>Loose</Button>
     </ActionMenu.Trigger>
-    <ActionMenu.Portal>
-      <ActionMenu.Content density="loose">
+      <ActionMenu.Content>
         <ActionMenu.Item>Action 1</ActionMenu.Item>
         <ActionMenu.Item>Action 2</ActionMenu.Item>
         <ActionMenu.Item>Action 3</ActionMenu.Item>
       </ActionMenu.Content>
-    </ActionMenu.Portal>
   </ActionMenu.Root>
-  <ActionMenu.Root>
+  <ActionMenu.Root density={"compact"}>
     <ActionMenu.Trigger asChild>
       <Button css={{ marginLeft: "15px", marginRight: "15px" }}>Compact</Button>
     </ActionMenu.Trigger>
-    <ActionMenu.Portal>
-      <ActionMenu.Content density="compact" align="start">
+      <ActionMenu.Content>
         <ActionMenu.Item>Action 1</ActionMenu.Item>
         <ActionMenu.Item>Action 2</ActionMenu.Item>
         <ActionMenu.Item>Action 3</ActionMenu.Item>
       </ActionMenu.Content>
-    </ActionMenu.Portal>
   </ActionMenu.Root>
 </Box>
 ```
 
+{/*
 ### Portal
 
 Description of portal
@@ -199,6 +193,7 @@ Description of guidance one
 ```jsx withPreview isGuide="error"
 <p>test</p>
 ```
+*/}
 
 ---
 

--- a/build.washingtonpost.com/docs/components/action-menu.mdx
+++ b/build.washingtonpost.com/docs/components/action-menu.mdx
@@ -52,12 +52,12 @@ The Action List can be triggered with a button, a link, an icon, or similar visu
         {`Action Button`}
       </Button>
     </ActionMenu.Trigger>
-      <ActionMenu.Content>
-        <ActionMenu.Item>Action 1</ActionMenu.Item>
-        <ActionMenu.Item>Action 2</ActionMenu.Item>
-        <ActionMenu.Item>Action 3</ActionMenu.Item>
-        <ActionMenu.Item>Action 4</ActionMenu.Item>
-      </ActionMenu.Content>
+    <ActionMenu.Content>
+      <ActionMenu.Item>Action 1</ActionMenu.Item>
+      <ActionMenu.Item>Action 2</ActionMenu.Item>
+      <ActionMenu.Item>Action 3</ActionMenu.Item>
+      <ActionMenu.Item>Action 4</ActionMenu.Item>
+    </ActionMenu.Content>
   </ActionMenu.Root>
   <ActionMenu.Root>
     <ActionMenu.Trigger asChild>
@@ -67,12 +67,12 @@ The Action List can be triggered with a button, a link, an icon, or similar visu
         </Icon>
       </Button>
     </ActionMenu.Trigger>
-      <ActionMenu.Content>
-        <ActionMenu.Item>Action 1</ActionMenu.Item>
-        <ActionMenu.Item>Action 2</ActionMenu.Item>
-        <ActionMenu.Item>Action 3</ActionMenu.Item>
-        <ActionMenu.Item>Action 4</ActionMenu.Item>
-      </ActionMenu.Content>
+    <ActionMenu.Content>
+      <ActionMenu.Item>Action 1</ActionMenu.Item>
+      <ActionMenu.Item>Action 2</ActionMenu.Item>
+      <ActionMenu.Item>Action 3</ActionMenu.Item>
+      <ActionMenu.Item>Action 4</ActionMenu.Item>
+    </ActionMenu.Content>
   </ActionMenu.Root>
   <ActionMenu.Root>
     <ActionMenu.Trigger
@@ -81,12 +81,12 @@ The Action List can be triggered with a button, a link, an icon, or similar visu
     >
       <a style={{ marginLeft: "35px", marginRight: "35px" }}>Action Link</a>
     </ActionMenu.Trigger>
-      <ActionMenu.Content>
-        <ActionMenu.Item>Action 1</ActionMenu.Item>
-        <ActionMenu.Item>Action 2</ActionMenu.Item>
-        <ActionMenu.Item>Action 3</ActionMenu.Item>
-        <ActionMenu.Item>Action 4</ActionMenu.Item>
-      </ActionMenu.Content>
+    <ActionMenu.Content>
+      <ActionMenu.Item>Action 1</ActionMenu.Item>
+      <ActionMenu.Item>Action 2</ActionMenu.Item>
+      <ActionMenu.Item>Action 3</ActionMenu.Item>
+      <ActionMenu.Item>Action 4</ActionMenu.Item>
+    </ActionMenu.Content>
   </ActionMenu.Root>
   <ActionMenu.Root>
     <ActionMenu.Trigger asChild>
@@ -130,70 +130,24 @@ The following options can be applied to specify the density of the items: `defau
     <ActionMenu.Trigger asChild>
       <Button css={{ marginLeft: "15px", marginRight: "15px" }}>Loose</Button>
     </ActionMenu.Trigger>
-      <ActionMenu.Content>
-        <ActionMenu.Item>Action 1</ActionMenu.Item>
-        <ActionMenu.Item>Action 2</ActionMenu.Item>
-        <ActionMenu.Item>Action 3</ActionMenu.Item>
-      </ActionMenu.Content>
+    <ActionMenu.Content>
+      <ActionMenu.Item>Action 1</ActionMenu.Item>
+      <ActionMenu.Item>Action 2</ActionMenu.Item>
+      <ActionMenu.Item>Action 3</ActionMenu.Item>
+    </ActionMenu.Content>
   </ActionMenu.Root>
   <ActionMenu.Root density={"compact"}>
     <ActionMenu.Trigger asChild>
       <Button css={{ marginLeft: "15px", marginRight: "15px" }}>Compact</Button>
     </ActionMenu.Trigger>
-      <ActionMenu.Content>
-        <ActionMenu.Item>Action 1</ActionMenu.Item>
-        <ActionMenu.Item>Action 2</ActionMenu.Item>
-        <ActionMenu.Item>Action 3</ActionMenu.Item>
-      </ActionMenu.Content>
+    <ActionMenu.Content>
+      <ActionMenu.Item>Action 1</ActionMenu.Item>
+      <ActionMenu.Item>Action 2</ActionMenu.Item>
+      <ActionMenu.Item>Action 3</ActionMenu.Item>
+    </ActionMenu.Content>
   </ActionMenu.Root>
 </Box>
 ```
-
-{/*
-### Portal
-
-Description of portal
-
-### Sub Menu
-
-Description of sub menu
-
-```jsx withPreview
-<p>test</p>
-```
-
----
-
-## Behavior
-
-### Open
-
-Opens on click
-
-```jsx withPreview
-<p>test</p>
-```
-
-### Open
-
-Sub navigation hover
-
-```jsx withPreview
-<p>test</p>
-```
-
----
-
-## Guidance
-
-### Guidance one
-
-Description of guidance one
-
-```jsx withPreview isGuide="error"
-<p>test</p>
-```
-*/}
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -49598,7 +49598,7 @@
     },
     "ui/action-menu": {
       "name": "@washingtonpost/wpds-action-menu",
-      "version": "1.7.0",
+      "version": "1.9.1",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-dropdown-menu": "^2.0.5",
@@ -51195,7 +51195,7 @@
       "license": "MIT",
       "dependencies": {
         "@washingtonpost/wpds-accordion": "1.9.1",
-        "@washingtonpost/wpds-action-menu": "*",
+        "@washingtonpost/wpds-action-menu": "1.9.1",
         "@washingtonpost/wpds-alert-banner": "1.9.1",
         "@washingtonpost/wpds-app-bar": "1.9.1",
         "@washingtonpost/wpds-avatar": "1.9.1",
@@ -66304,7 +66304,7 @@
       "version": "file:ui/kit",
       "requires": {
         "@washingtonpost/wpds-accordion": "1.9.1",
-        "@washingtonpost/wpds-action-menu": "*",
+        "@washingtonpost/wpds-action-menu": "1.9.1",
         "@washingtonpost/wpds-alert-banner": "1.9.1",
         "@washingtonpost/wpds-app-bar": "1.9.1",
         "@washingtonpost/wpds-avatar": "1.9.1",

--- a/ui/action-menu/src/ActionMenuCheckboxItem.tsx
+++ b/ui/action-menu/src/ActionMenuCheckboxItem.tsx
@@ -31,13 +31,12 @@ const StyledCheckboxItem = styled(ActionMenuPrimitive.CheckboxItem, {
       compact: {
         padding: theme.space["050"],
         paddingLeft: theme.space["200"],
-      }
-    }
+      },
+    },
   },
   defaultVariants: {
     density: "default",
   },
-
 });
 
 export type ActionMenuCheckboxItemProps = {
@@ -51,7 +50,6 @@ export const ActionMenuCheckboxItem = React.forwardRef<
   HTMLDivElement,
   ActionMenuCheckboxItemProps
 >(({ children, ...props }: ActionMenuCheckboxItemProps, ref) => {
-
   const context = React.useContext(ActionMenuContext);
 
   return (

--- a/ui/action-menu/src/ActionMenuContent.tsx
+++ b/ui/action-menu/src/ActionMenuContent.tsx
@@ -43,30 +43,28 @@ export const ActionMenuContent = React.forwardRef<
   HTMLDivElement,
   ActionMenuContentProps
 >(({ children, ...props }: ActionMenuContentProps, ref) => {
-
   const [clicked, setClicked] = React.useState(false);
 
   return (
     <ActionMenuPortal>
-      <StyledContent 
-        {...props} 
-        ref={ref} 
-        sideOffset={4} 
+      <StyledContent
+        {...props}
+        ref={ref}
+        sideOffset={4}
         onMouseDown={() => {
           setClicked(true);
         }}
         onPointerDownOutside={() => {
-            setClicked(true);
+          setClicked(true);
         }}
         onCloseAutoFocus={(event) => {
-            if (clicked) {
-              setClicked(false);
-              event.preventDefault();
-            }
+          if (clicked) {
+            setClicked(false);
+            event.preventDefault();
           }
-        }
-        >
-          {children}
+        }}
+      >
+        {children}
       </StyledContent>
     </ActionMenuPortal>
   );

--- a/ui/action-menu/src/ActionMenuContent.tsx
+++ b/ui/action-menu/src/ActionMenuContent.tsx
@@ -44,14 +44,29 @@ export const ActionMenuContent = React.forwardRef<
   ActionMenuContentProps
 >(({ children, ...props }: ActionMenuContentProps, ref) => {
 
+  const [clicked, setClicked] = React.useState(false);
+
   return (
     <ActionMenuPortal>
-      <StyledContent
-        {...props}
-        ref={ref}
-        sideOffset={4}
-      >
-        {children}
+      <StyledContent 
+        {...props} 
+        ref={ref} 
+        sideOffset={4} 
+        onMouseDown={() => {
+          setClicked(true);
+        }}
+        onPointerDownOutside={() => {
+            setClicked(true);
+        }}
+        onCloseAutoFocus={(event) => {
+            if (clicked) {
+              setClicked(false);
+              event.preventDefault();
+            }
+          }
+        }
+        >
+          {children}
       </StyledContent>
     </ActionMenuPortal>
   );

--- a/ui/action-menu/src/ActionMenuContent.tsx
+++ b/ui/action-menu/src/ActionMenuContent.tsx
@@ -23,9 +23,9 @@ export const ContentStyles = {
   maxHeight: "var(--radix-dropdown-menu-content-available-height)",
   maxWidth: "var(--radix-dropdown-menu-content-available-width)",
   minWidth: "200px",
-  overflow: "auto",
+  overflowX: "hidden",
+  overflowY: "auto",
   width: "fit-content",
-  padding: "1px",
 };
 
 const StyledContent = styled(ActionMenuPrimitive.Content, {

--- a/ui/action-menu/src/ActionMenuContent.tsx
+++ b/ui/action-menu/src/ActionMenuContent.tsx
@@ -3,7 +3,6 @@ import * as React from "react";
 import WPDS, { theme, styled } from "@washingtonpost/wpds-theme";
 
 import * as ActionMenuPrimitive from "@radix-ui/react-dropdown-menu";
-import { ActionMenuContext } from "./context";
 
 import { DropdownMenuContentProps as RadixDropdownMenuContentProps } from "@radix-ui/react-dropdown-menu";
 
@@ -44,19 +43,12 @@ export const ActionMenuContent = React.forwardRef<
   HTMLDivElement,
   ActionMenuContentProps
 >(({ children, ...props }: ActionMenuContentProps, ref) => {
-  const context = React.useContext(ActionMenuContext);
 
-  const handleInteractOutside = () => {
-    const item = context?.stack.shift();
-
-    context?.setStack([item ? item : ""]);
-  };
   return (
     <ActionMenuPortal>
       <StyledContent
         {...props}
         ref={ref}
-        onInteractOutside={handleInteractOutside}
         sideOffset={4}
       >
         {children}

--- a/ui/action-menu/src/ActionMenuIcon.tsx
+++ b/ui/action-menu/src/ActionMenuIcon.tsx
@@ -28,17 +28,16 @@ export type ActionMenuIconProps = {
 export const ActionMenuIcon = React.forwardRef<
   HTMLDivElement,
   ActionMenuIconProps
->(({ children,
-     side = "left",
-     ...props }: ActionMenuIconProps, ref) => {
-    return (
-
-        (side === "left") ? 
-            <LeftIcon {...props} ref={ref} className="action-menu-icon">{children}</LeftIcon> :
-        <RightIcon {...props} ref={ref} className="action-menu-icon">{children}</RightIcon>
-        
-
-    );
+>(({ children, side = "left", ...props }: ActionMenuIconProps, ref) => {
+  return side === "left" ? (
+    <LeftIcon {...props} ref={ref} className="action-menu-icon">
+      {children}
+    </LeftIcon>
+  ) : (
+    <RightIcon {...props} ref={ref} className="action-menu-icon">
+      {children}
+    </RightIcon>
+  );
 });
 
 ActionMenuIcon.displayName = "ActionMenuIcon";

--- a/ui/action-menu/src/ActionMenuIcon.tsx
+++ b/ui/action-menu/src/ActionMenuIcon.tsx
@@ -40,3 +40,5 @@ export const ActionMenuIcon = React.forwardRef<
 
     );
 });
+
+ActionMenuIcon.displayName = "ActionMenuIcon";

--- a/ui/action-menu/src/ActionMenuItem.tsx
+++ b/ui/action-menu/src/ActionMenuItem.tsx
@@ -12,13 +12,17 @@ const NAME = "ActionMenuItem";
 export const ItemStyles = {
   alignItems: "center",
   background: theme.colors.secondary,
+  borderRadius: theme.radii["050"],
   display: "flex",
   flexBasis: "auto",
   flexDirection: "row",
   justifyContent: "flex-start",
   flexWrap: "none",
+  marginTop: "1px",
+  marginBottom: "1px",
+  marginLeft: "1px",
   transition: `background ${theme.transitions.fast} ${theme.transitions.inOut}`,
-  width: "100%",
+  width: "calc(100% - 2px)",
   "&:hover": {
     backgroundColor: theme.colors.alpha25,
     cursor: "pointer",

--- a/ui/action-menu/src/ActionMenuItem.tsx
+++ b/ui/action-menu/src/ActionMenuItem.tsx
@@ -47,17 +47,15 @@ export const ItemStyles = {
       },
       compact: {
         padding: theme.space["050"],
-      }
-    }
+      },
+    },
   },
   defaultVariants: {
     density: "default",
   },
 };
 
-export const ContentDensityVariants = {
-};
-
+export const ContentDensityVariants = {};
 
 // export const ItemContent = styled("div", {
 //   display: "flex",
@@ -77,11 +75,15 @@ export const ActionMenuItem = React.forwardRef<
   HTMLDivElement,
   ActionMenuItemProps
 >(({ children, ...props }: ActionMenuItemProps, ref) => {
-
   const context = React.useContext(ActionMenuContext);
 
   return (
-    <StyledItem {...props} ref={ref} density={context.density} className="action-menu-item">
+    <StyledItem
+      {...props}
+      ref={ref}
+      density={context.density}
+      className="action-menu-item"
+    >
       {children}
     </StyledItem>
   );

--- a/ui/action-menu/src/ActionMenuItemIndicator.tsx
+++ b/ui/action-menu/src/ActionMenuItemIndicator.tsx
@@ -47,7 +47,7 @@ export type ActionMenuItemIndicatorProps = {
 export const ActionMenuItemIndicator = React.forwardRef<
   HTMLDivElement,
   ActionMenuItemIndicatorProps
->(({ children, ...props }: ActionMenuItemIndicatorProps, ref) => {
+>(({ ...props }: ActionMenuItemIndicatorProps, ref) => {
 
   const context = React.useContext(ActionMenuContext);
 

--- a/ui/action-menu/src/ActionMenuItemIndicator.tsx
+++ b/ui/action-menu/src/ActionMenuItemIndicator.tsx
@@ -29,8 +29,8 @@ export const StyledItemIndicator = styled(ActionMenuPrimitive.ItemIndicator, {
       },
       compact: {
         left: theme.space["050"],
-      }
-    }
+      },
+    },
   },
   defaultVariants: {
     density: "default",
@@ -48,7 +48,6 @@ export const ActionMenuItemIndicator = React.forwardRef<
   HTMLDivElement,
   ActionMenuItemIndicatorProps
 >(({ ...props }: ActionMenuItemIndicatorProps, ref) => {
-
   const context = React.useContext(ActionMenuContext);
 
   return (

--- a/ui/action-menu/src/ActionMenuLabel.tsx
+++ b/ui/action-menu/src/ActionMenuLabel.tsx
@@ -31,8 +31,8 @@ export const StyledLabel = styled(ActionMenuPrimitive.Label, {
         paddingLeft: theme.space["050"],
         paddingRight: theme.space["050"],
         marginTop: theme.sizes["050"],
-      }
-    }
+      },
+    },
   },
   defaultVariants: {
     density: "default",
@@ -50,10 +50,14 @@ export const ActionMenuLabel = React.forwardRef<
   HTMLDivElement,
   ActionMenuLabelProps
 >(({ children, ...props }: ActionMenuLabelProps, ref) => {
-
   const context = React.useContext(ActionMenuContext);
   return (
-    <StyledLabel {...props} ref={ref} density={context.density} className="action-menu-label">
+    <StyledLabel
+      {...props}
+      ref={ref}
+      density={context.density}
+      className="action-menu-label"
+    >
       {children}
     </StyledLabel>
   );

--- a/ui/action-menu/src/ActionMenuRadioItem.tsx
+++ b/ui/action-menu/src/ActionMenuRadioItem.tsx
@@ -30,8 +30,8 @@ export const StyledRadioItem = styled(ActionMenuPrimitive.RadioItem, {
       compact: {
         padding: theme.space["050"],
         paddingLeft: theme.space["200"],
-      }
-    }
+      },
+    },
   },
   defaultVariants: {
     density: "default",
@@ -51,7 +51,12 @@ export const ActionMenuRadioItem = React.forwardRef<
 >(({ children, ...props }: ActionMenuRadioItemProps, ref) => {
   const context = React.useContext(ActionMenuContext);
   return (
-    <StyledRadioItem {...props} ref={ref} density={context.density} className="action-menu-checkbox-item">
+    <StyledRadioItem
+      {...props}
+      ref={ref}
+      density={context.density}
+      className="action-menu-checkbox-item"
+    >
       {children}
     </StyledRadioItem>
   );

--- a/ui/action-menu/src/ActionMenuRoot.tsx
+++ b/ui/action-menu/src/ActionMenuRoot.tsx
@@ -10,8 +10,7 @@ import { ActionMenuContext } from "./context";
 
 const NAME = "ActionMenuRoot";
 
-const StyledActionMenu = styled(ActionMenuPrimitive.Root, {
-});
+const StyledActionMenu = styled(ActionMenuPrimitive.Root, {});
 
 export type DensityProp = "loose" | "default" | "compact";
 
@@ -27,12 +26,11 @@ export const ActionMenuRoot = ({
   density = "default",
   ...props
 }: ActionMenuRootProps) => {
-
   return (
     <ActionMenuContext.Provider
       value={{
         density,
-        level: 1
+        level: 1,
       }}
     >
       <StyledActionMenu {...props} />

--- a/ui/action-menu/src/ActionMenuRoot.tsx
+++ b/ui/action-menu/src/ActionMenuRoot.tsx
@@ -8,13 +8,9 @@ import * as ActionMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import { DropdownMenuProps as RadixDropdownMenuProps } from "@radix-ui/react-dropdown-menu";
 import { ActionMenuContext } from "./context";
 
-// import type * as RadixDropdownTypes from "@radix-ui/react-dropdown-menu";
-
 const NAME = "ActionMenuRoot";
 
 const StyledActionMenu = styled(ActionMenuPrimitive.Root, {
-  // minWidth: "max-content"
-  // width: "300px"
 });
 
 export type DensityProp = "loose" | "default" | "compact";
@@ -31,24 +27,12 @@ export const ActionMenuRoot = ({
   density = "default",
   ...props
 }: ActionMenuRootProps) => {
-  const [stack, setStack] = React.useState([window?.crypto.randomUUID()]);
-  const [currentId, setCurrentId] = React.useState("");
-  const [previousId, setPreviousId] = React.useState("");
-
-  const advance = ({ current, previous }) => {
-    setCurrentId(current);
-    setPreviousId(previous);
-  };
 
   return (
     <ActionMenuContext.Provider
       value={{
-        advance,
-        currentId,
         density,
-        previousId,
-        stack,
-        setStack,
+        level: 1
       }}
     >
       <StyledActionMenu {...props} />

--- a/ui/action-menu/src/ActionMenuSub.tsx
+++ b/ui/action-menu/src/ActionMenuSub.tsx
@@ -13,7 +13,6 @@ const NAME = "ActionMenuSub";
 export const StyledSub = styled(ActionMenuPrimitive.Sub, {});
 
 export type ActionMenuSubProps = {
-  onOpenChange?: () => void;
   /** Any React node may be used as a child to allow for formatting */
   children?: React.ReactNode;
   /** Override CSS */
@@ -21,7 +20,6 @@ export type ActionMenuSubProps = {
 } & RadixDropdownMenuSubProps;
 
 export const ActionMenuSub = ({
-  onOpenChange = () => undefined,
   ...props
 }: ActionMenuSubProps) => {
   const context = React.useContext(ActionMenuContext);

--- a/ui/action-menu/src/ActionMenuSub.tsx
+++ b/ui/action-menu/src/ActionMenuSub.tsx
@@ -25,37 +25,6 @@ export const ActionMenuSub = ({
   ...props
 }: ActionMenuSubProps) => {
   const context = React.useContext(ActionMenuContext);
-  const [id] = React.useState(window?.crypto.randomUUID());
-
-  // true or false tells us if we are going up or down
-  const trackSubMenuDepth = (open) => {
-    if (open) {
-      context.stack.push(id);
-
-      const current = context.stack[context.stack.length - 1];
-      const previous = context.stack[context.stack.length - 2];
-
-      context.advance({
-        current,
-        previous,
-      });
-
-      return;
-    }
-
-    const previous = context.stack.pop();
-    const current = context.stack[context.stack.length - 1];
-
-    context.advance({
-      current,
-      previous,
-    });
-  };
-
-  const handleOpenChange = (open) => {
-    trackSubMenuDepth(open);
-    onOpenChange(open);
-  };
 
   return (
     <ActionMenuContext.Provider
@@ -63,7 +32,7 @@ export const ActionMenuSub = ({
         ...context,
       }}
     >
-      <StyledSub {...props} onOpenChange={handleOpenChange} />
+      <StyledSub {...props} />
     </ActionMenuContext.Provider>
   );
 };

--- a/ui/action-menu/src/ActionMenuSub.tsx
+++ b/ui/action-menu/src/ActionMenuSub.tsx
@@ -19,9 +19,7 @@ export type ActionMenuSubProps = {
   css?: WPDS.CSS;
 } & RadixDropdownMenuSubProps;
 
-export const ActionMenuSub = ({
-  ...props
-}: ActionMenuSubProps) => {
+export const ActionMenuSub = ({ ...props }: ActionMenuSubProps) => {
   const context = React.useContext(ActionMenuContext);
 
   return (

--- a/ui/action-menu/src/ActionMenuSub.tsx
+++ b/ui/action-menu/src/ActionMenuSub.tsx
@@ -19,7 +19,9 @@ export type ActionMenuSubProps = {
   css?: WPDS.CSS;
 } & RadixDropdownMenuSubProps;
 
-export const ActionMenuSub = ({ ...props }: ActionMenuSubProps) => {
+export const ActionMenuSub = ({
+  ...props
+}: ActionMenuSubProps) => {
   const context = React.useContext(ActionMenuContext);
 
   return (

--- a/ui/action-menu/src/ActionMenuSubContent.tsx
+++ b/ui/action-menu/src/ActionMenuSubContent.tsx
@@ -62,21 +62,17 @@ export const ActionMenuSubContent = React.forwardRef<
   const [shadowSize, setShadowSize] = React.useState("small" as ShadowProp);
 
   React.useEffect(() => {
-    setShadowSize(
-      context?.level > 2
-        ? "large"
-        : "small"
-    );
+    setShadowSize(context?.level > 2 ? "large" : "small");
   }, []);
 
   return (
     <StyledPortal>
       <ActionMenuContext.Provider
-          value={{
-            density: context.density,
-            level: context.level + 1,
-          }}
-        >
+        value={{
+          density: context.density,
+          level: context.level + 1,
+        }}
+      >
         <StyledSubContent
           {...props}
           ref={ref}
@@ -86,8 +82,8 @@ export const ActionMenuSubContent = React.forwardRef<
           {children}
         </StyledSubContent>
       </ActionMenuContext.Provider>
-  </StyledPortal>
-);
+    </StyledPortal>
+  );
 });
 
 ActionMenuSubContent.displayName = NAME;

--- a/ui/action-menu/src/ActionMenuSubContent.tsx
+++ b/ui/action-menu/src/ActionMenuSubContent.tsx
@@ -81,7 +81,7 @@ export const ActionMenuSubContent = React.forwardRef<
           {...props}
           ref={ref}
           shadowSize={shadowSize}
-          alignOffset={-2} // Offset the ActionMenuContent border and focus ring padding
+          alignOffset={-2} // Offset the ActionMenuContent border
         >
           {children}
         </StyledSubContent>

--- a/ui/action-menu/src/ActionMenuSubContent.tsx
+++ b/ui/action-menu/src/ActionMenuSubContent.tsx
@@ -63,7 +63,7 @@ export const ActionMenuSubContent = React.forwardRef<
 
   React.useEffect(() => {
     setShadowSize(
-      context?.stack.findIndex((item) => item === context.currentId) >= 1
+      context?.level > 2
         ? "large"
         : "small"
     );
@@ -71,14 +71,21 @@ export const ActionMenuSubContent = React.forwardRef<
 
   return (
     <StyledPortal>
-      <StyledSubContent
-        {...props}
-        ref={ref}
-        shadowSize={shadowSize}
-        alignOffset={-1} // Offset the ActionMenuContent border
-      >
-        {children}
-      </StyledSubContent>
+      <ActionMenuContext.Provider
+          value={{
+            density: context.density,
+            level: context.level + 1,
+          }}
+        >
+        <StyledSubContent
+          {...props}
+          ref={ref}
+          shadowSize={shadowSize}
+          alignOffset={-2} // Offset the ActionMenuContent border and focus ring padding
+        >
+          {children}
+        </StyledSubContent>
+      </ActionMenuContext.Provider>
   </StyledPortal>
 );
 });

--- a/ui/action-menu/src/ActionMenuSubTrigger.tsx
+++ b/ui/action-menu/src/ActionMenuSubTrigger.tsx
@@ -12,6 +12,9 @@ const NAME = "ActionMenuSubTrigger";
 
 const SubTriggerStyles = {
   ...ItemStyles,
+  "&[data-state=open]": {
+    outline: "none",
+  },
   variants: {
     density: {
       loose: {

--- a/ui/action-menu/src/ActionMenuSubTrigger.tsx
+++ b/ui/action-menu/src/ActionMenuSubTrigger.tsx
@@ -14,6 +14,7 @@ const SubTriggerStyles = {
   ...ItemStyles,
   "&[data-state=open]": {
     outline: "none",
+    backgroundColor: theme.colors.alpha25,
   },
   variants: {
     density: {

--- a/ui/action-menu/src/context.tsx
+++ b/ui/action-menu/src/context.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 type ContextType = {
   density: "default" | "loose" | "compact";
   level: number;
+  trigger?: React.ReactNode;
 };
 
 export const ActionMenuContext = React.createContext<ContextType>({

--- a/ui/action-menu/src/context.tsx
+++ b/ui/action-menu/src/context.tsx
@@ -1,26 +1,11 @@
 import * as React from "react";
-import { ActionMenuContent } from "./ActionMenuContent";
-
-//export const DensityContext = createContext("default");
 
 type ContextType = {
-  advance: ({ current, previous }) => void;
-  currActiveGroup?: React.ReactNode;
-  currentId: string;
   density: "default" | "loose" | "compact";
-  previousId: string;
-  slider?: boolean;
-  stack: string[];
-  setStack: React.Dispatch<React.SetStateAction<string[]>>;
+  level: number;
 };
 
 export const ActionMenuContext = React.createContext<ContextType>({
-  advance: ({ current, previous }) => undefined,
-  currActiveGroup: <ActionMenuContent />,
-  currentId: "",
   density: "default",
-  previousId: "",
-  slider: false,
-  stack: [""],
-  setStack: () => undefined,
+  level: 1,
 });

--- a/ui/action-menu/src/play.stories.tsx
+++ b/ui/action-menu/src/play.stories.tsx
@@ -46,11 +46,11 @@ const SimpleContent = (
         <Component.Sub>
           <Component.SubTrigger>Action 1.1</Component.SubTrigger>
           <Component.SubContent>
-              <Component.Item>Action 1.1.1</Component.Item>
-              <Component.Item>Action 1.1.2</Component.Item>
-              <Component.Item>Action 1.1.3</Component.Item>
-              <Component.Item>Action 1.1.4</Component.Item>
-            </Component.SubContent>
+            <Component.Item>Action 1.1.1</Component.Item>
+            <Component.Item>Action 1.1.2</Component.Item>
+            <Component.Item>Action 1.1.3</Component.Item>
+            <Component.Item>Action 1.1.4</Component.Item>
+          </Component.SubContent>
         </Component.Sub>
         <Component.Item>Action 1.2</Component.Item>
         <Component.Item>Action 1.3</Component.Item>
@@ -322,7 +322,9 @@ const ItemVariationsTemplate = (parameters) => {
 
 export const ItemVariations = ItemVariationsTemplate.bind({});
 
-const InteractionsTemplate: ComponentStory<typeof Component.Root> = (parameters) => (
+const InteractionsTemplate: ComponentStory<typeof Component.Root> = (
+  parameters
+) => (
   <Component.Root {...parameters}>
     <Component.Trigger asChild>
       <Button>Trigger</Button>

--- a/ui/action-menu/src/play.stories.tsx
+++ b/ui/action-menu/src/play.stories.tsx
@@ -278,7 +278,6 @@ const ItemVariationsTemplate = (parameters) => {
             </Component.SubContent>
           </Component.Sub>
           <Component.Item>Action 4</Component.Item>
-
           <Component.Sub>
             <Component.SubTrigger>More actions</Component.SubTrigger>
             <Component.SubContent>

--- a/ui/action-menu/src/play.stories.tsx
+++ b/ui/action-menu/src/play.stories.tsx
@@ -323,7 +323,7 @@ const ItemVariationsTemplate = (parameters) => {
 
 export const ItemVariations = ItemVariationsTemplate.bind({});
 
-const InteractionsTemplate: ComponentStory<any> = (parameters) => (
+const InteractionsTemplate: ComponentStory<typeof Component.Root> = (parameters) => (
   <Component.Root {...parameters}>
     <Component.Trigger asChild>
       <Button>Trigger</Button>
@@ -385,7 +385,7 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-Interactions.play = async ({ parameters }) => {
+Interactions.play = async () => {
   console.log("Start Interaction");
 
   const trigger = screen.getAllByText("Trigger")[0];


### PR DESCRIPTION
## What I did
Simplified context so that docs page works. Got rid of some of the props we were using for the slider behavior since that is backlogged for now, removed RandomUUID which was breaking docs page
<!--
  Explain the **motivation** for making this change. What existing problem does the pull request solve? Please be as detailed as possible.
-->
