### PR TITLE
fix: streamline release process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ main-publish:
 	npx lerna publish from-package --yes --no-git-reset --no-verify-access
 
 main-version:
-	npx lerna version --conventional-commits --yes --force-publish --create-release github
+	npx lerna version --conventional-commits --yes --force-publish --create-release github --no-push
 
 # create experimental release
 experimental-release:
@@ -19,7 +19,8 @@ experimental-release:
 # create main release
 main-release:
 	make main-version
-	npm run turbo:build:force
+	npm run turbo:build:ui:force
+	npm run format
 	make main-publish
 	npm install
 

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "build-storybook": "npm run turbo:build;build-storybook --force-build-preview --quiet",
     "turbo:build": "turbo run build",
     "turbo:build:force": "turbo run build --force",
+    "turbo:build:ui:force": "turbo run build --force --filter={./ui/*}... --filter=!@washingtonpost/wpds-kitchen-sink",
     "test": "jest",
     "size": "lerna run size",
     "main-publish": "make main-publish",


### PR DESCRIPTION
## What I did

This PR updated the release process to only build the ui packages after versioning and before publishing

SRED-338