### PR TITLE
fix: update Husky env variable name used in CI

### DIFF
--- a/.github/workflows/latest-release.yml
+++ b/.github/workflows/latest-release.yml
@@ -41,10 +41,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-          HUSKY_SKIP_HOOKS: 1
+          HUSKY: 0
 
       - uses: stefanzweifel/git-auto-commit-action@v4
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-          HUSKY_SKIP_HOOKS: 1
+          HUSKY: 0


### PR DESCRIPTION
## What I did

Husky changed its environment variable names [after v4](https://typicode.github.io/husky/migrating-from-v4.html). Update to [new HUSKY variable](https://typicode.github.io/husky/guide.html#with-env-variables)
