### PR TITLE
fix: allow for RadioButtons in RadioGroup to wrap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -111,10 +111,10 @@
       }
     },
     "apps/vite-project": {
-      "version": "1.10.0",
+      "version": "1.11.0",
       "dependencies": {
-        "@washingtonpost/wpds-kitchen-sink": "1.10.0",
-        "@washingtonpost/wpds-ui-kit": "1.10.0",
+        "@washingtonpost/wpds-kitchen-sink": "1.11.0",
+        "@washingtonpost/wpds-ui-kit": "1.11.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -172,10 +172,10 @@
       }
     },
     "apps/vite-v2-project": {
-      "version": "1.10.0",
+      "version": "1.11.0",
       "dependencies": {
-        "@washingtonpost/wpds-kitchen-sink": "1.10.0",
-        "@washingtonpost/wpds-ui-kit": "1.10.0",
+        "@washingtonpost/wpds-kitchen-sink": "1.11.0",
+        "@washingtonpost/wpds-ui-kit": "1.11.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
       },
@@ -678,7 +678,7 @@
     },
     "build.washingtonpost.com": {
       "name": "@washingtonpost/wpds-docs",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/standalone": "^7.17.11",
@@ -692,11 +692,11 @@
         "@stitches/react": "1.2.8",
         "@washingtonpost/site-favicons": "^0.1.3",
         "@washingtonpost/tachyons-css": "^1.8.0",
-        "@washingtonpost/wpds-accordion": "1.10.0",
+        "@washingtonpost/wpds-accordion": "1.11.0",
         "@washingtonpost/wpds-assets": "1.22.0",
-        "@washingtonpost/wpds-kitchen-sink": "1.10.0",
-        "@washingtonpost/wpds-tailwind-theme": "1.10.0",
-        "@washingtonpost/wpds-ui-kit": "1.10.0",
+        "@washingtonpost/wpds-kitchen-sink": "1.11.0",
+        "@washingtonpost/wpds-tailwind-theme": "1.11.0",
+        "@washingtonpost/wpds-ui-kit": "1.11.0",
         "fuse.js": "^6.6.2",
         "gray-matter": "^4.0.2",
         "lz-string": "^1.4.4",
@@ -48833,13 +48833,13 @@
     },
     "ui/accordion": {
       "name": "@washingtonpost/wpds-accordion",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-accordion": "^1.1.0",
         "@washingtonpost/wpds-assets": "^1.22.0",
-        "@washingtonpost/wpds-icon": "1.10.0",
-        "@washingtonpost/wpds-theme": "1.10.0"
+        "@washingtonpost/wpds-icon": "1.11.0",
+        "@washingtonpost/wpds-theme": "1.11.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -48930,15 +48930,15 @@
     },
     "ui/action-menu": {
       "name": "@washingtonpost/wpds-action-menu",
-      "version": "1.9.1",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-dropdown-menu": "2.0.3",
         "@washingtonpost/wpds-assets": "^1.20.0",
-        "@washingtonpost/wpds-button": "^1.7.0",
-        "@washingtonpost/wpds-divider": "^1.9.1",
-        "@washingtonpost/wpds-icon": "*",
-        "@washingtonpost/wpds-theme": "*"
+        "@washingtonpost/wpds-button": "1.11.0",
+        "@washingtonpost/wpds-divider": "1.11.0",
+        "@washingtonpost/wpds-icon": "1.11.0",
+        "@washingtonpost/wpds-theme": "1.11.0"
       },
       "devDependencies": {
         "@types/node": "^20.4.2",
@@ -48961,15 +48961,15 @@
     },
     "ui/alert-banner": {
       "name": "@washingtonpost/wpds-alert-banner",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-app-bar": "1.10.0",
+        "@washingtonpost/wpds-app-bar": "1.11.0",
         "@washingtonpost/wpds-assets": "^1.22.0",
-        "@washingtonpost/wpds-button": "1.10.0",
-        "@washingtonpost/wpds-container": "1.10.0",
-        "@washingtonpost/wpds-icon": "1.10.0",
-        "@washingtonpost/wpds-theme": "1.10.0",
+        "@washingtonpost/wpds-button": "1.11.0",
+        "@washingtonpost/wpds-container": "1.11.0",
+        "@washingtonpost/wpds-icon": "1.11.0",
+        "@washingtonpost/wpds-theme": "1.11.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {
@@ -49000,10 +49000,10 @@
     },
     "ui/app-bar": {
       "name": "@washingtonpost/wpds-app-bar",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.10.0",
+        "@washingtonpost/wpds-theme": "1.11.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {
@@ -49017,11 +49017,11 @@
     },
     "ui/avatar": {
       "name": "@washingtonpost/wpds-avatar",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-avatar": "latest",
-        "@washingtonpost/wpds-theme": "1.10.0"
+        "@washingtonpost/wpds-theme": "1.11.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -49050,10 +49050,10 @@
     },
     "ui/box": {
       "name": "@washingtonpost/wpds-box",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.10.0",
+        "@washingtonpost/wpds-theme": "1.11.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {
@@ -49067,10 +49067,10 @@
     },
     "ui/button": {
       "name": "@washingtonpost/wpds-button",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.10.0",
+        "@washingtonpost/wpds-theme": "1.11.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {
@@ -49084,10 +49084,10 @@
     },
     "ui/card": {
       "name": "@washingtonpost/wpds-card",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.10.0"
+        "@washingtonpost/wpds-theme": "1.11.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -49100,16 +49100,16 @@
     },
     "ui/carousel": {
       "name": "@washingtonpost/wpds-carousel",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "^1.0.0",
         "@radix-ui/react-use-controllable-state": "^1.0.0",
         "@washingtonpost/wpds-assets": "^1.22.0",
-        "@washingtonpost/wpds-button": "1.10.0",
-        "@washingtonpost/wpds-icon": "1.10.0",
-        "@washingtonpost/wpds-pagination-dots": "1.10.0",
-        "@washingtonpost/wpds-theme": "1.10.0",
+        "@washingtonpost/wpds-button": "1.11.0",
+        "@washingtonpost/wpds-icon": "1.11.0",
+        "@washingtonpost/wpds-pagination-dots": "1.11.0",
+        "@washingtonpost/wpds-theme": "1.11.0",
         "nanoid": "^3.3.4",
         "react-swipeable": "^7.0.0"
       },
@@ -49128,16 +49128,16 @@
     },
     "ui/checkbox": {
       "name": "@washingtonpost/wpds-checkbox",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.0.0",
         "@washingtonpost/wpds-assets": "^1.22.0",
-        "@washingtonpost/wpds-icon": "1.10.0",
-        "@washingtonpost/wpds-input-label": "1.10.0",
-        "@washingtonpost/wpds-input-shared": "1.10.0",
-        "@washingtonpost/wpds-theme": "1.10.0",
-        "@washingtonpost/wpds-visually-hidden": "1.10.0",
+        "@washingtonpost/wpds-icon": "1.11.0",
+        "@washingtonpost/wpds-input-label": "1.11.0",
+        "@washingtonpost/wpds-input-shared": "1.11.0",
+        "@washingtonpost/wpds-theme": "1.11.0",
+        "@washingtonpost/wpds-visually-hidden": "1.11.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {
@@ -49211,10 +49211,10 @@
     },
     "ui/container": {
       "name": "@washingtonpost/wpds-container",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.10.0",
+        "@washingtonpost/wpds-theme": "1.11.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {
@@ -49228,11 +49228,11 @@
     },
     "ui/divider": {
       "name": "@washingtonpost/wpds-divider",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-separator": "^1.0.0",
-        "@washingtonpost/wpds-theme": "1.10.0"
+        "@washingtonpost/wpds-theme": "1.11.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -49269,15 +49269,15 @@
     },
     "ui/drawer": {
       "name": "@washingtonpost/wpds-drawer",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-focus-scope": "^1.0.0",
         "@washingtonpost/wpds-assets": "^1.22.0",
-        "@washingtonpost/wpds-button": "1.10.0",
-        "@washingtonpost/wpds-icon": "1.10.0",
-        "@washingtonpost/wpds-scrim": "1.10.0",
-        "@washingtonpost/wpds-theme": "1.10.0",
+        "@washingtonpost/wpds-button": "1.11.0",
+        "@washingtonpost/wpds-icon": "1.11.0",
+        "@washingtonpost/wpds-scrim": "1.11.0",
+        "@washingtonpost/wpds-theme": "1.11.0",
         "react-transition-group": "^4.4.5"
       },
       "devDependencies": {
@@ -49307,10 +49307,10 @@
     },
     "ui/error-message": {
       "name": "@washingtonpost/wpds-error-message",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.10.0"
+        "@washingtonpost/wpds-theme": "1.11.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -49323,10 +49323,10 @@
     },
     "ui/eslint-plugin": {
       "name": "@washingtonpost/eslint-plugin-wpds",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.10.0"
+        "@washingtonpost/wpds-theme": "1.11.0"
       },
       "devDependencies": {
         "jest": "^28.1.0"
@@ -49337,10 +49337,10 @@
     },
     "ui/fieldset": {
       "name": "@washingtonpost/wpds-fieldset",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.10.0"
+        "@washingtonpost/wpds-theme": "1.11.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -49353,10 +49353,10 @@
     },
     "ui/helper-text": {
       "name": "@washingtonpost/wpds-helper-text",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.10.0"
+        "@washingtonpost/wpds-theme": "1.11.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -49369,11 +49369,11 @@
     },
     "ui/icon": {
       "name": "@washingtonpost/wpds-icon",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.10.0",
-        "@washingtonpost/wpds-visually-hidden": "1.10.0",
+        "@washingtonpost/wpds-theme": "1.11.0",
+        "@washingtonpost/wpds-visually-hidden": "1.11.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {
@@ -49388,12 +49388,12 @@
     },
     "ui/input-label": {
       "name": "@washingtonpost/wpds-input-label",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-label": "^1.0.0",
-        "@washingtonpost/wpds-input-shared": "1.10.0",
-        "@washingtonpost/wpds-theme": "1.10.0"
+        "@washingtonpost/wpds-input-shared": "1.11.0",
+        "@washingtonpost/wpds-theme": "1.11.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -49407,12 +49407,12 @@
     },
     "ui/input-password": {
       "name": "@washingtonpost/wpds-input-password",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@washingtonpost/wpds-assets": "^1.22.0",
-        "@washingtonpost/wpds-icon": "1.10.0",
-        "@washingtonpost/wpds-input-text": "1.10.0"
+        "@washingtonpost/wpds-icon": "1.11.0",
+        "@washingtonpost/wpds-input-text": "1.11.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -49439,16 +49439,16 @@
     },
     "ui/input-search": {
       "name": "@washingtonpost/wpds-input-search",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@reach/combobox": "^0.18.0",
         "@reach/popover": "^0.18.0",
         "@washingtonpost/wpds-assets": "^1.22.0",
-        "@washingtonpost/wpds-icon": "1.10.0",
-        "@washingtonpost/wpds-input-label": "1.10.0",
-        "@washingtonpost/wpds-input-text": "1.10.0",
-        "@washingtonpost/wpds-theme": "1.10.0",
+        "@washingtonpost/wpds-icon": "1.11.0",
+        "@washingtonpost/wpds-input-label": "1.11.0",
+        "@washingtonpost/wpds-input-text": "1.11.0",
+        "@washingtonpost/wpds-theme": "1.11.0",
         "match-sorter": "6.3.1"
       },
       "devDependencies": {
@@ -49466,10 +49466,10 @@
     },
     "ui/input-shared": {
       "name": "@washingtonpost/wpds-input-shared",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.10.0"
+        "@washingtonpost/wpds-theme": "1.11.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -49482,19 +49482,19 @@
     },
     "ui/input-text": {
       "name": "@washingtonpost/wpds-input-text",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-label": "^1.0.0",
         "@washingtonpost/wpds-assets": "^1.22.0",
-        "@washingtonpost/wpds-button": "1.10.0",
-        "@washingtonpost/wpds-error-message": "1.10.0",
-        "@washingtonpost/wpds-helper-text": "1.10.0",
-        "@washingtonpost/wpds-icon": "1.10.0",
-        "@washingtonpost/wpds-input-label": "1.10.0",
-        "@washingtonpost/wpds-input-shared": "1.10.0",
-        "@washingtonpost/wpds-theme": "1.10.0",
-        "@washingtonpost/wpds-visually-hidden": "1.10.0",
+        "@washingtonpost/wpds-button": "1.11.0",
+        "@washingtonpost/wpds-error-message": "1.11.0",
+        "@washingtonpost/wpds-helper-text": "1.11.0",
+        "@washingtonpost/wpds-icon": "1.11.0",
+        "@washingtonpost/wpds-input-label": "1.11.0",
+        "@washingtonpost/wpds-input-shared": "1.11.0",
+        "@washingtonpost/wpds-theme": "1.11.0",
+        "@washingtonpost/wpds-visually-hidden": "1.11.0",
         "nanoid": "^3.3.4"
       },
       "devDependencies": {
@@ -49539,14 +49539,14 @@
     },
     "ui/input-textarea": {
       "name": "@washingtonpost/wpds-input-textarea",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-error-message": "1.10.0",
-        "@washingtonpost/wpds-helper-text": "1.10.0",
-        "@washingtonpost/wpds-input-label": "1.10.0",
-        "@washingtonpost/wpds-input-shared": "1.10.0",
-        "@washingtonpost/wpds-theme": "1.10.0",
+        "@washingtonpost/wpds-error-message": "1.11.0",
+        "@washingtonpost/wpds-helper-text": "1.11.0",
+        "@washingtonpost/wpds-input-label": "1.11.0",
+        "@washingtonpost/wpds-input-shared": "1.11.0",
+        "@washingtonpost/wpds-theme": "1.11.0",
         "nanoid": "^3.3.4",
         "react": "^16.8.6 || ^17.0.2"
       },
@@ -49565,44 +49565,44 @@
     },
     "ui/kit": {
       "name": "@washingtonpost/wpds-ui-kit",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/eslint-plugin-wpds": "1.10.0",
-        "@washingtonpost/wpds-accordion": "1.10.0",
-        "@washingtonpost/wpds-action-menu": "*",
-        "@washingtonpost/wpds-alert-banner": "1.10.0",
-        "@washingtonpost/wpds-app-bar": "1.10.0",
-        "@washingtonpost/wpds-avatar": "1.10.0",
-        "@washingtonpost/wpds-box": "1.10.0",
-        "@washingtonpost/wpds-button": "1.10.0",
-        "@washingtonpost/wpds-card": "1.10.0",
-        "@washingtonpost/wpds-carousel": "1.10.0",
-        "@washingtonpost/wpds-checkbox": "1.10.0",
-        "@washingtonpost/wpds-container": "1.10.0",
-        "@washingtonpost/wpds-divider": "1.10.0",
-        "@washingtonpost/wpds-drawer": "1.10.0",
-        "@washingtonpost/wpds-error-message": "1.10.0",
-        "@washingtonpost/wpds-fieldset": "1.10.0",
-        "@washingtonpost/wpds-helper-text": "1.10.0",
-        "@washingtonpost/wpds-icon": "1.10.0",
-        "@washingtonpost/wpds-input-label": "1.10.0",
-        "@washingtonpost/wpds-input-password": "1.10.0",
-        "@washingtonpost/wpds-input-search": "1.10.0",
-        "@washingtonpost/wpds-input-shared": "1.10.0",
-        "@washingtonpost/wpds-input-text": "1.10.0",
-        "@washingtonpost/wpds-input-textarea": "1.10.0",
-        "@washingtonpost/wpds-navigation-menu": "1.10.0",
-        "@washingtonpost/wpds-pagination-dots": "1.10.0",
-        "@washingtonpost/wpds-popover": "1.10.0",
-        "@washingtonpost/wpds-radio-group": "1.10.0",
-        "@washingtonpost/wpds-scrim": "1.10.0",
-        "@washingtonpost/wpds-select": "1.10.0",
-        "@washingtonpost/wpds-switch": "1.10.0",
-        "@washingtonpost/wpds-tabs": "1.10.0",
-        "@washingtonpost/wpds-theme": "1.10.0",
-        "@washingtonpost/wpds-tooltip": "1.10.0",
-        "@washingtonpost/wpds-visually-hidden": "1.10.0"
+        "@washingtonpost/eslint-plugin-wpds": "1.11.0",
+        "@washingtonpost/wpds-accordion": "1.11.0",
+        "@washingtonpost/wpds-action-menu": "1.11.0",
+        "@washingtonpost/wpds-alert-banner": "1.11.0",
+        "@washingtonpost/wpds-app-bar": "1.11.0",
+        "@washingtonpost/wpds-avatar": "1.11.0",
+        "@washingtonpost/wpds-box": "1.11.0",
+        "@washingtonpost/wpds-button": "1.11.0",
+        "@washingtonpost/wpds-card": "1.11.0",
+        "@washingtonpost/wpds-carousel": "1.11.0",
+        "@washingtonpost/wpds-checkbox": "1.11.0",
+        "@washingtonpost/wpds-container": "1.11.0",
+        "@washingtonpost/wpds-divider": "1.11.0",
+        "@washingtonpost/wpds-drawer": "1.11.0",
+        "@washingtonpost/wpds-error-message": "1.11.0",
+        "@washingtonpost/wpds-fieldset": "1.11.0",
+        "@washingtonpost/wpds-helper-text": "1.11.0",
+        "@washingtonpost/wpds-icon": "1.11.0",
+        "@washingtonpost/wpds-input-label": "1.11.0",
+        "@washingtonpost/wpds-input-password": "1.11.0",
+        "@washingtonpost/wpds-input-search": "1.11.0",
+        "@washingtonpost/wpds-input-shared": "1.11.0",
+        "@washingtonpost/wpds-input-text": "1.11.0",
+        "@washingtonpost/wpds-input-textarea": "1.11.0",
+        "@washingtonpost/wpds-navigation-menu": "1.11.0",
+        "@washingtonpost/wpds-pagination-dots": "1.11.0",
+        "@washingtonpost/wpds-popover": "1.11.0",
+        "@washingtonpost/wpds-radio-group": "1.11.0",
+        "@washingtonpost/wpds-scrim": "1.11.0",
+        "@washingtonpost/wpds-select": "1.11.0",
+        "@washingtonpost/wpds-switch": "1.11.0",
+        "@washingtonpost/wpds-tabs": "1.11.0",
+        "@washingtonpost/wpds-theme": "1.11.0",
+        "@washingtonpost/wpds-tooltip": "1.11.0",
+        "@washingtonpost/wpds-visually-hidden": "1.11.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -49648,11 +49648,11 @@
     },
     "ui/kitchen-sink": {
       "name": "@washingtonpost/wpds-kitchen-sink",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@washingtonpost/wpds-assets": "latest",
-        "@washingtonpost/wpds-ui-kit": "1.10.0",
+        "@washingtonpost/wpds-ui-kit": "1.11.0",
         "nanoid": "^3.3.4"
       },
       "devDependencies": {
@@ -49667,12 +49667,12 @@
     },
     "ui/navigation-menu": {
       "name": "@washingtonpost/wpds-navigation-menu",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.7",
         "@radix-ui/react-navigation-menu": "^1.1.2",
-        "@washingtonpost/wpds-theme": "1.10.0",
+        "@washingtonpost/wpds-theme": "1.11.0",
         "popper-max-size-modifier": "^0.2.0",
         "react-popper": "^2.3.0",
         "react-transition-group": "^4.4.5"
@@ -49688,10 +49688,10 @@
     },
     "ui/pagination-dots": {
       "name": "@washingtonpost/wpds-pagination-dots",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.10.0"
+        "@washingtonpost/wpds-theme": "1.11.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -49704,14 +49704,14 @@
     },
     "ui/popover": {
       "name": "@washingtonpost/wpds-popover",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-popover": "^1.0.2",
         "@washingtonpost/wpds-assets": "^1.22.0",
-        "@washingtonpost/wpds-button": "1.10.0",
-        "@washingtonpost/wpds-icon": "1.10.0",
-        "@washingtonpost/wpds-theme": "1.10.0"
+        "@washingtonpost/wpds-button": "1.11.0",
+        "@washingtonpost/wpds-icon": "1.11.0",
+        "@washingtonpost/wpds-theme": "1.11.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -49724,14 +49724,14 @@
     },
     "ui/radio-group": {
       "name": "@washingtonpost/wpds-radio-group",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-radio-group": "^1.0.0",
-        "@washingtonpost/wpds-error-message": "1.10.0",
-        "@washingtonpost/wpds-fieldset": "1.10.0",
-        "@washingtonpost/wpds-input-label": "1.10.0",
-        "@washingtonpost/wpds-theme": "1.10.0",
+        "@washingtonpost/wpds-error-message": "1.11.0",
+        "@washingtonpost/wpds-fieldset": "1.11.0",
+        "@washingtonpost/wpds-input-label": "1.11.0",
+        "@washingtonpost/wpds-theme": "1.11.0",
         "nanoid": "^3.3.3"
       },
       "devDependencies": {
@@ -49827,11 +49827,11 @@
     },
     "ui/scrim": {
       "name": "@washingtonpost/wpds-scrim",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.0.0",
-        "@washingtonpost/wpds-theme": "1.10.0",
+        "@washingtonpost/wpds-theme": "1.11.0",
         "react-transition-group": "^4.4.5"
       },
       "devDependencies": {
@@ -49845,17 +49845,17 @@
     },
     "ui/select": {
       "name": "@washingtonpost/wpds-select",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-select": "^1.2.2",
         "@radix-ui/react-use-controllable-state": "^1.0.0",
         "@washingtonpost/wpds-assets": "^1.22.0",
-        "@washingtonpost/wpds-divider": "1.10.0",
-        "@washingtonpost/wpds-icon": "1.10.0",
-        "@washingtonpost/wpds-input-label": "1.10.0",
-        "@washingtonpost/wpds-input-shared": "1.10.0",
-        "@washingtonpost/wpds-theme": "1.10.0",
+        "@washingtonpost/wpds-divider": "1.11.0",
+        "@washingtonpost/wpds-icon": "1.11.0",
+        "@washingtonpost/wpds-input-label": "1.11.0",
+        "@washingtonpost/wpds-input-shared": "1.11.0",
+        "@washingtonpost/wpds-theme": "1.11.0",
         "nanoid": "^3.3.4"
       },
       "devDependencies": {
@@ -49893,11 +49893,11 @@
     },
     "ui/switch": {
       "name": "@washingtonpost/wpds-switch",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-switch": "^1.0.1",
-        "@washingtonpost/wpds-theme": "1.10.0"
+        "@washingtonpost/wpds-theme": "1.11.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -49910,15 +49910,15 @@
     },
     "ui/tabs": {
       "name": "@washingtonpost/wpds-tabs",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "^1.0.2",
         "@radix-ui/react-tabs": "latest",
         "@washingtonpost/wpds-assets": "^1.22.0",
         "@washingtonpost/wpds-icon": "1.1.0",
-        "@washingtonpost/wpds-theme": "1.10.0",
-        "@washingtonpost/wpds-tooltip": "1.10.0",
+        "@washingtonpost/wpds-theme": "1.11.0",
+        "@washingtonpost/wpds-tooltip": "1.11.0",
         "react-transition-group": "^4.4.5"
       },
       "devDependencies": {
@@ -50030,10 +50030,10 @@
     },
     "ui/tailwind-theme": {
       "name": "@washingtonpost/wpds-tailwind-theme",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.10.0"
+        "@washingtonpost/wpds-theme": "1.11.0"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.14",
@@ -50259,7 +50259,7 @@
     },
     "ui/theme": {
       "name": "@washingtonpost/wpds-theme",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@stitches/react": "^1.2.8"
@@ -50271,11 +50271,11 @@
     },
     "ui/tooltip": {
       "name": "@washingtonpost/wpds-tooltip",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-tooltip": "^1.0.0",
-        "@washingtonpost/wpds-theme": "1.10.0"
+        "@washingtonpost/wpds-theme": "1.11.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -50289,10 +50289,10 @@
     },
     "ui/visually-hidden": {
       "name": "@washingtonpost/wpds-visually-hidden",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.10.0",
+        "@washingtonpost/wpds-theme": "1.11.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {

--- a/ui/radio-group/src/RadioGroup.tsx
+++ b/ui/radio-group/src/RadioGroup.tsx
@@ -9,9 +9,10 @@ import { ErrorMessage } from "@washingtonpost/wpds-error-message";
 
 const NAME = "RadioGroup";
 
-const RadioGroupInputsCSS = Theme.css({
+const RadioGroupInputs = Theme.styled("div", {
   display: "flex",
   flexDirection: "column",
+  flexWrap: "wrap",
   gap: Theme.theme.space["025"],
   "[data-orientation='horizontal'] > &": {
     alignItems: "center",
@@ -34,6 +35,8 @@ type CombinedProps = Pick<
   React.ComponentPropsWithRef<"fieldset">;
 
 interface RadioGroupProps extends CombinedProps {
+  /** CSS passed to RadioButtons parent element */
+  buttonsWrapperCss?: WPDS.CSS;
   /** Override CSS */
   css?: WPDS.CSS;
   /** Inputs are disabled, changing appearance and preventing input */
@@ -60,6 +63,7 @@ export const RadioGroup = React.forwardRef<
 >(
   (
     {
+      buttonsWrapperCss,
       children,
       css,
       defaultValue,
@@ -107,7 +111,7 @@ export const RadioGroup = React.forwardRef<
           aria-errormessage={error ? errorId : undefined}
           {...props}
         >
-          <div className={RadioGroupInputsCSS()}>
+          <RadioGroupInputs css={buttonsWrapperCss}>
             {React.Children.map(children, (child) => {
               if (React.isValidElement(child)) {
                 return React.cloneElement(child, {
@@ -118,7 +122,7 @@ export const RadioGroup = React.forwardRef<
                 });
               }
             })}
-          </div>
+          </RadioGroupInputs>
           {errorMessage && (
             <ErrorMessage id={errorId} aria-live="assertive">
               {errorMessage}

--- a/ui/radio-group/src/play.stories.tsx
+++ b/ui/radio-group/src/play.stories.tsx
@@ -3,6 +3,7 @@ import { screen, userEvent } from "@storybook/testing-library";
 import { expect } from "@storybook/jest";
 import { RadioGroup as Component, RadioButton } from "./";
 import { styled, css, theme } from "@washingtonpost/wpds-theme";
+import { Box } from "../../box";
 
 import type { ComponentMeta, ComponentStory } from "@storybook/react";
 
@@ -35,6 +36,37 @@ RadioGroup.argTypes = {
 };
 
 RadioGroup.parameters = {
+  chromatic: { disableSnapshot: true },
+};
+
+const WrapTemplate: ComponentStory<typeof Component> = (args) => (
+  <Box
+    css={{
+      border: "1px dashed gray",
+      maxWidth: "350px",
+      padding: theme.space["100"],
+    }}
+  >
+    <Component {...args} buttonsWrapperCss={{ border: "1px dashed gray" }}>
+      <RadioButton label="Option 1" value="opt1" id="opt1" />
+      <RadioButton label="Option 2" value="opt2" id="opt2" />
+      <RadioButton label="Option 3" value="opt3" id="opt3" />
+      <RadioButton label="Option 4" value="opt4" id="opt4" />
+      <RadioButton label="Option 5" value="opt5" id="opt5" />
+      <RadioButton label="Option 6" value="opt6" id="opt6" />
+    </Component>
+  </Box>
+);
+
+export const WrapOptions = WrapTemplate.bind({});
+
+WrapOptions.args = {
+  legend: "Select an option",
+  name: "my-value",
+  orientation: "horizontal",
+};
+
+WrapOptions.parameters = {
   chromatic: { disableSnapshot: true },
 };
 


### PR DESCRIPTION
## What I did

This PR updates the default behavior of horizontally oriented groups of RadioButtons to wrap if they exceed the width of their container.

It also exposes a new css prop to allow for styling of the RadioButtons containing element

SRED-375
