### PR TITLE
fix: set root to be category of each

### DIFF
--- a/build.washingtonpost.com/components/Layout/Components/Sidebar.js
+++ b/build.washingtonpost.com/components/Layout/Components/Sidebar.js
@@ -234,7 +234,7 @@ export default function Sidebar({ navigation, setMobileMenu }) {
             return (
               <StyledAccordionRoot
                 key={index}
-                defaultValue={"Components"}
+                defaultValue={nav.category}
                 type="single"
                 collapsible
               >


### PR DESCRIPTION
## What I did

Since we are already rendering two root components by default just updated the category to be the default value of the one accordion in that root. A happy mistake seems like of not using the accordion in a single root but works out in our favor to have them both as a group. 
