### PR TITLE
feat: add useActiveDescendant hook to simplify child element focus in Carousel

### DIFF
--- a/build.washingtonpost.com/docs/components/carousel.mdx
+++ b/build.washingtonpost.com/docs/components/carousel.mdx
@@ -912,42 +912,52 @@ Add `aria-labelledby` to Carousel Items to allow the screen-reader to read the c
 export default function Example() {
   const items = [
     {
+      id: "story-1",
       kicker: " ",
       headline: "Politics stops at the water’s edge?",
       blurb:
         "Traveling abroad ahead of a likely run for president, Ron DeSantis took shots at his domestic political foes.",
     },
     {
+      id: "story-2",
       kicker: "ELECTIONS",
       headline: "5 facts about Julie Chavez Rodriguez",
       blurb:
         "Julie Chavez Rodriguez, who will run the Biden-Harris 2024 reelection bid, is the granddaughter of legendary labor leader Cesar Chavez.",
     },
     {
+      id: "story-3",
       kicker: "JUSTICE",
       headline: "What to know about E. Jean Carroll civil case",
       blurb:
         "In addition to facing criminal charges in Manhattan, Donald Trump is a defendant in a civil lawsuit over an alleged rape decades ago.",
     },
     {
+      id: "story-4",
       kicker: " ",
       headline: "Biden threatens to veto House GOP bill",
       blurb:
         'In a statement opposing the GOP\'s debt ceiling bill, the White House said House Republicans are pursuing "a reckless attempt to extract extreme concessions."',
     },
     {
+      id: "story-5",
       kicker: " ",
       headline: "Republicans counter Biden announcement",
       blurb:
         "Republicans used a dystopian video created with artificial intelligence technology to counter Biden’s announcement of his reelection campaign.",
     },
     {
+      id: "story-6",
       kicker: "THE FIX",
       headline: "Alito’s remarkable reasoning",
       blurb:
         "Alito suggested the Biden administration might simply disregard an unfavorable ruling on mifepristone. Here's what he appears to be talking about.",
     },
   ];
+
+  const { addDescendant, contentProps, handleDescendantFocus } =
+    useActiveDescendant();
+
   return (
     <Box
       css={{
@@ -955,7 +965,7 @@ export default function Example() {
         width: "100vw",
       }}
     >
-      <Carousel.Root itemsPerPage={1}>
+      <Carousel.Root itemsPerPage={1} onDescendantFocus={handleDescendantFocus}>
         <Carousel.Header>
           <Carousel.HeaderContent>
             <Carousel.Title>Carousel Title</Carousel.Title>
@@ -965,10 +975,11 @@ export default function Example() {
             <Carousel.NextButton />
           </Carousel.HeaderActions>
         </Carousel.Header>
-        <Carousel.Content aria-live="polite">
+        <Carousel.Content aria-live="polite" {...contentProps}>
           {items.map((item, i) => (
             <Carousel.Item
-              key={item.headline}
+              key={item.id}
+              id={item.id}
               aria-labelledby={`article-heading-${i}`}
             >
               <Card
@@ -1031,6 +1042,15 @@ export default function Example() {
                     color: "$accessible",
                     fontSize: "$087",
                     textDecoration: "none",
+                  }}
+                  tabIndex={-1}
+                  id={`${item.id}-link`}
+                  ref={(el) => {
+                    addDescendant({
+                      element: el,
+                      id: `${item.id}-link`,
+                      parentId: item.id,
+                    });
                   }}
                 >
                   By The Washington Post

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@storybook/testing-library": "^0.0.13",
         "@testing-library/dom": "^8.9.1",
         "@testing-library/jest-dom": "^5.14.1",
-        "@testing-library/react": "^12.1.2",
+        "@testing-library/react": "^12.1.5",
         "@testing-library/react-hooks": "^8.0.1",
         "@testing-library/user-event": "^13.5.0",
         "@types/jest": "^28.1.8",
@@ -17905,20 +17905,21 @@
       }
     },
     "node_modules/@testing-library/react": {
-      "version": "12.1.4",
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.5.tgz",
+      "integrity": "sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^8.0.0",
-        "@types/react-dom": "*"
+        "@types/react-dom": "<18.0.0"
       },
       "engines": {
         "node": ">=12"
       },
       "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
+        "react": "<18.0.0",
+        "react-dom": "<18.0.0"
       }
     },
     "node_modules/@testing-library/react-hooks": {
@@ -20374,11 +20375,12 @@
       }
     },
     "node_modules/aria-query": {
-      "version": "5.0.0",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
       "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=6.0"
+      "dependencies": {
+        "deep-equal": "^2.0.5"
       }
     },
     "node_modules/arr-diff": {
@@ -20403,6 +20405,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
+      "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-array-buffer": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array-differ": {
@@ -24484,6 +24499,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deep-equal": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.2.tgz",
+      "integrity": "sha512-xjVyBf0w5vH0I42jdAZzOKVldmPgSulmiyPRywoyq7HXC9qdgo17kxJE+rdnif5Tz6+pIrpJI8dCpMNLIGkUiA==",
+      "dev": true,
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.2",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.1",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.2",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.5.0",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.9"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "dev": true,
@@ -24792,6 +24836,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.0.tgz",
+      "integrity": "sha512-UzGwzcjyv3OtAvolTj1GoyNYzfFR+iqbGjcnBEENZVCpM4/Ng1yhGNvS3lR/xDS74Tb2wGG9WzNSNIOS9UVb2g==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.2.1",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/define-lazy-prop": {
       "version": "2.0.0",
       "dev": true,
@@ -24801,10 +24859,12 @@
       }
     },
     "node_modules/define-properties": {
-      "version": "1.1.4",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
+        "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       },
@@ -28638,9 +28698,10 @@
       "license": "MIT"
     },
     "node_modules/functions-have-names": {
-      "version": "1.2.2",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -28693,12 +28754,14 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.0",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
+        "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3"
       },
       "funding": {
@@ -31621,12 +31684,34 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/is-weakmap": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
+      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-weakref": {
       "version": "1.0.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
+      "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -35203,8 +35288,9 @@
       }
     },
     "node_modules/lz-string": {
-      "version": "1.4.4",
-      "license": "WTFPL",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -42312,13 +42398,14 @@
       }
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.4.3",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
+      "integrity": "sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "functions-have-names": "^1.2.2"
+        "define-properties": "^1.2.0",
+        "set-function-name": "^2.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -43835,6 +43922,20 @@
       "version": "2.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
+      "integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
+      "dev": true,
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/set-value": {
       "version": "2.0.1",
@@ -48376,6 +48477,21 @@
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
+      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+      "dev": true,
+      "dependencies": {
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-weakmap": "^2.0.1",
+        "is-weakset": "^2.0.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@storybook/testing-library": "^0.0.13",
     "@testing-library/dom": "^8.9.1",
     "@testing-library/jest-dom": "^5.14.1",
-    "@testing-library/react": "^12.1.2",
+    "@testing-library/react": "^12.1.5",
     "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^13.5.0",
     "@types/jest": "^28.1.8",

--- a/ui/carousel/src/CarouselContent.tsx
+++ b/ui/carousel/src/CarouselContent.tsx
@@ -246,7 +246,6 @@ export const CarouselContent = React.forwardRef<
         <Slider css={{ transform: `translateX(${xPos}px)` }}>
           {React.Children.map(children, (child, index) => {
             if (React.isValidElement(child)) {
-              console.log();
               return React.cloneElement(
                 child as React.ReactElement<CarouselItemProps>,
                 {

--- a/ui/carousel/src/CarouselItem.tsx
+++ b/ui/carousel/src/CarouselItem.tsx
@@ -12,7 +12,7 @@ const Container = styled("li", {
     focused: {
       true: {
         "& > *": {
-          outline: `2px solid ${theme.colors.cta}`,
+          outline: `2px solid ${theme.colors.signal}`,
           outlineOffset: "-2px",
           position: "relative",
           zIndex: 1,

--- a/ui/carousel/src/CarouselRoot.tsx
+++ b/ui/carousel/src/CarouselRoot.tsx
@@ -44,7 +44,7 @@ export type CarouselRootProps = {
   /** callback for page change */
   onPageChange?: () => void;
   /** callback for internal focus */
-  onDescendentFocus?: (index: number) => void;
+  onDescendantFocus?: (id: string) => void;
   /* TODO :: do we need these?
   onScroll={event => {}}        // default `undefined`
   onDragScroll={event => {}}    // default `undefined`
@@ -59,7 +59,7 @@ export const CarouselRoot = React.forwardRef<HTMLDivElement, CarouselRootProps>(
       defaultPage,
       onPageChange,
       itemsPerPage = "auto",
-      onDescendentFocus = () => undefined,
+      onDescendantFocus = () => undefined,
       children,
       ...props
     },
@@ -74,18 +74,14 @@ export const CarouselRoot = React.forwardRef<HTMLDivElement, CarouselRootProps>(
     const [titleId, setTitleId] = React.useState<string | undefined>();
     const [activeId, setActiveId] = React.useState<string | undefined>();
     const [isTransitioning, setIsTransitioning] = React.useState(false);
-    const prevIndex = React.useRef();
+    const prevId = React.useRef<string>();
 
     React.useEffect(() => {
-      let currentIndex;
-      if (activeId) {
-        currentIndex = parseInt(activeId.split("item")[1], 10);
+      if (activeId && prevId.current !== activeId) {
+        onDescendantFocus(activeId);
+        prevId.current = activeId;
       }
-      if (prevIndex.current !== currentIndex) {
-        onDescendentFocus(currentIndex);
-        prevIndex.current = currentIndex;
-      }
-    }, [activeId, onDescendentFocus]);
+    }, [activeId, onDescendantFocus]);
 
     return (
       <CarouselContext.Provider

--- a/ui/carousel/src/index.ts
+++ b/ui/carousel/src/index.ts
@@ -7,5 +7,7 @@ export * from "./CarouselTitle";
 export * from "./CarouselPreviousButton";
 export * from "./CarouselNextButton";
 export * from "./CarouselContent";
+export * from "./CarouselItem";
 export * from "./CarouselFooter";
 export * from "./CarouselDots";
+export * from "./useActiveDescendant";

--- a/ui/carousel/src/play.stories.jsx
+++ b/ui/carousel/src/play.stories.jsx
@@ -1,6 +1,9 @@
 import * as React from "react";
+import { screen, userEvent } from "@storybook/testing-library";
+import { expect } from "@storybook/jest";
 import { styled, theme } from "@washingtonpost/wpds-theme";
 import { Carousel as Component } from "./";
+import { Box } from "@washingtonpost/wpds-box";
 import { Button } from "@washingtonpost/wpds-button";
 import { Icon } from "@washingtonpost/wpds-icon";
 import { Play, Pause } from "@washingtonpost/wpds-assets";
@@ -547,3 +550,75 @@ const VerticalVideoTemplate = () => {
 };
 
 export const VerticalVideo = VerticalVideoTemplate.bind({});
+
+const InteractionsTemplate = () => {
+  const items = [{ id: "item-1" }, { id: "item-2" }, { id: "item-3" }];
+  const { handleDescendantFocus, contentProps, addDescendant } =
+    useActiveDescendant();
+  return (
+    <Box css={{ border: "1px dotted gray", width: "416px" }}>
+      <Component.Root
+        itemsPerPage={1}
+        onDescendantFocus={handleDescendantFocus}
+      >
+        <Component.Header>
+          <Component.HeaderContent>
+            <Component.Title>My Carousel</Component.Title>
+          </Component.HeaderContent>
+          <Component.HeaderActions>
+            <Component.PreviousButton />
+            <Component.NextButton />
+          </Component.HeaderActions>
+        </Component.Header>
+        <Component.Content {...contentProps}>
+          {items.map((item, i) => (
+            <Component.Item key={item.id} id={item.id}>
+              <div
+                style={{
+                  width: "200px",
+                  height: "200px",
+                  padding: theme.space["100"],
+                  marginInlineEnd: theme.space["050"],
+                }}
+              >
+                <p>{i + 1}</p>
+                <a
+                  href="#"
+                  tabIndex={-1}
+                  id={`${item.id}-link`}
+                  ref={(el) => {
+                    addDescendant({
+                      element: el,
+                      id: `${item.id}-link`,
+                      parentId: item.id,
+                    });
+                  }}
+                >
+                  Link
+                </a>
+              </div>
+            </Component.Item>
+          ))}
+        </Component.Content>
+        <Component.Footer>
+          <Component.Dots />
+        </Component.Footer>
+      </Component.Root>
+    </Box>
+  );
+};
+
+export const Interactions = InteractionsTemplate.bind({});
+Interactions.parameters = {
+  chromatic: { disableSnapshot: true },
+};
+
+Interactions.play = async () => {
+  const groups = screen.getAllByRole("group");
+  const content = groups[1];
+  await userEvent.tab();
+  await userEvent.tab();
+  await userEvent.tab();
+  await userEvent.keyboard("[ArrowDown]");
+  expect(content).toHaveAttribute("aria-activedescendant", "item-1-link");
+};

--- a/ui/carousel/src/play.stories.jsx
+++ b/ui/carousel/src/play.stories.jsx
@@ -1,10 +1,10 @@
 import * as React from "react";
-import { styled, theme, css } from "@washingtonpost/wpds-theme";
+import { styled, theme } from "@washingtonpost/wpds-theme";
 import { Carousel as Component } from "./";
 import { Button } from "@washingtonpost/wpds-button";
 import { Icon } from "@washingtonpost/wpds-icon";
 import { Play, Pause } from "@washingtonpost/wpds-assets";
-import { useEffect } from "react";
+import { useActiveDescendant } from "./useActiveDescendant";
 
 export default {
   title: "Carousel",
@@ -94,7 +94,6 @@ Carousel.argTypes = {
 const StoryLink = ({ href }) => (
   <div style={{ marginInlineEnd: theme.space["050"] }}>
     <a href={href} tabIndex={-1}>
-      {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
         src="https://fakeimg.pl/200x200/ddd/999/?text=Story+Headline&font=museo&font_size=24"
         width="200"
@@ -281,21 +280,36 @@ const Subtitle = styled("div", {
 
 const BrightsCarouselTemplate = (args) => {
   const stories = [
-    "https://www.washingtonpost.com",
-    "https://www.washingtonpost.com",
-    "https://www.washingtonpost.com",
-    "https://www.washingtonpost.com",
-    "https://www.washingtonpost.com",
+    {
+      id: "story-1",
+      url: "https://www.washingtonpost.com",
+    },
+    {
+      id: "story-2",
+      url: "https://www.washingtonpost.com",
+    },
+    {
+      id: "story-3",
+      url: "https://www.washingtonpost.com",
+    },
+    {
+      id: "story-4",
+      url: "https://www.washingtonpost.com",
+    },
+    {
+      id: "story-5",
+      url: "https://www.washingtonpost.com",
+    },
   ];
 
-  const [focusedIndex, setFocusedIndex] = React.useState();
+  const [focused, setFocused] = React.useState();
 
   const triggerActiveLink = () => {
-    window.open(stories[focusedIndex]);
+    window.open(focused.url);
   };
 
-  const handleDescendentFocus = (i) => {
-    setFocusedIndex(i);
+  const handleDescendantFocus = (id) => {
+    setFocused(stories.find((story) => story.id === id));
   };
 
   const handleOnKeyDown = (event) => {
@@ -318,7 +332,7 @@ const BrightsCarouselTemplate = (args) => {
     <Component.Root
       {...args}
       itemsPerPage={1}
-      onDescendentFocus={handleDescendentFocus}
+      onDescendantFocus={handleDescendantFocus}
     >
       <Component.Header
         css={{
@@ -361,9 +375,9 @@ const BrightsCarouselTemplate = (args) => {
           }}
         />
         <Component.Content onKeyDown={handleOnKeyDown} onKeyUp={handleOnKeyUp}>
-          {stories.map((url, i) => (
-            <Component.Item key={`item${i}`}>
-              <StoryLink href={url} />
+          {stories.map((story) => (
+            <Component.Item key={story.id} id={story.id}>
+              <StoryLink href={story.url} />
             </Component.Item>
           ))}
         </Component.Content>
@@ -380,96 +394,17 @@ BrightsCarousel.parameters = {
 
 const VerticalVideoTemplate = () => {
   const videos = [
-    { headline: "Title 1", byline: "Author 1" },
-    { headline: "Title 2", byline: "Author 2" },
-    { headline: "Title 3", byline: "Author 3" },
-    { headline: "Title 4", byline: "Author 4" },
-    { headline: "Title 5", byline: "Author 5" },
+    { id: "title-1", headline: "Title 1", byline: "Author 1" },
+    { id: "title-2", headline: "Title 2", byline: "Author 2" },
+    { id: "title-3", headline: "Title 3", byline: "Author 3" },
+    { id: "title-4", headline: "Title 4", byline: "Author 4" },
+    { id: "title-5", headline: "Title 5", byline: "Author 5" },
   ];
 
-  const [activeIndex, setActiveIndex] = React.useState();
-  const [activeChildIndex, setActiveChildIndex] = React.useState();
-  const [descendantId, setDescendantId] = React.useState();
-
-  const handleDescendentFocus = (index) => {
-    if (index === undefined) {
-      setActiveIndex(undefined);
-      setActiveChildIndex(undefined);
-      setDescendantId(undefined);
-    } else {
-      setActiveIndex(index);
-      setActiveChildIndex(-1);
-      setDescendantId(undefined);
-    }
-  };
-
-  useEffect(() => {
-    if (activeIndex === undefined || activeChildIndex === undefined) return;
-    const el = childRefs.current[activeIndex][activeChildIndex];
-    if (el) {
-      setDescendantId(el.id);
-    }
-  }, [activeIndex, activeChildIndex]);
-
-  const childRefs = React.useRef([[], [], [], [], []]);
-
-  const triggerActiveElement = () => {
-    const el = childRefs.current[activeIndex][activeChildIndex];
-    if (!el) return;
-    el.click();
-  };
-
-  const handleOnKeyDown = (event) => {
-    switch (event.key) {
-      case "Up":
-      case "ArrowUp":
-        setActiveChildIndex((prev) => {
-          if (prev - 1 >= 0) {
-            return prev - 1;
-          } else {
-            return prev;
-          }
-        });
-        break;
-
-      case "ArrowDown":
-      case "Down":
-        setActiveChildIndex((prev) => {
-          if (prev + 1 <= 2) {
-            return prev + 1;
-          } else {
-            return prev;
-          }
-        });
-        break;
-      case " ":
-        event.preventDefault();
-        break;
-      case "Enter":
-        event.preventDefault();
-        triggerActiveElement();
-        break;
-    }
-  };
-
-  const handleOnKeyUp = (event) => {
-    if (event.key === " ") {
-      event.preventDefault();
-      triggerActiveElement();
-    }
-  };
-
-  const focused = css({
-    outline: `2px solid ${theme.colors.cta}`,
-  });
-
-  const hasFocus = (root, type) => {
-    const id = `${root.toLowerCase().replace(/\s+/g, "")}-${type}`;
-    return id === descendantId;
-  };
-
+  const { addDescendant, handleDescendantFocus, contentProps } =
+    useActiveDescendant();
   return (
-    <Component.Root itemsPerPage={1} onDescendentFocus={handleDescendentFocus}>
+    <Component.Root itemsPerPage={1} onDescendantFocus={handleDescendantFocus}>
       <Component.Header
         css={{
           borderBlockStart: `1px solid ${theme.colors.primary}`,
@@ -509,12 +444,9 @@ const VerticalVideoTemplate = () => {
             },
           }}
         />
-        <Component.Content
-          onKeyDown={handleOnKeyDown}
-          aria-activedescendant={descendantId}
-        >
-          {videos.map((video, index) => (
-            <Component.Item key={video.headline}>
+        <Component.Content {...contentProps}>
+          {videos.map((video) => (
+            <Component.Item key={video.id} id={video.id}>
               <div
                 style={{ marginInlineEnd: theme.space["100"], padding: "2px" }}
               >
@@ -528,7 +460,6 @@ const VerticalVideoTemplate = () => {
                     position: "relative",
                   }}
                 >
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
                   <img
                     alt="a very good boy"
                     src="https://www.washingtonpost.com/resizer/drBpb5wRPLd4rcxcAW71ZmwPYdQ=/376x658/filters:quality(80)/posttv-thumbnails-prod.s3.amazonaws.com/10-07-2022/t_927b58b469fe41c6a1f4a46e7e9ea96d_name_Screen_Shot_2022_10_07_at_1_05_42_PM.png"
@@ -541,18 +472,19 @@ const VerticalVideoTemplate = () => {
                   />
                   <Button
                     variant="primary"
-                    id={`${video.headline
-                      .toLowerCase()
-                      .replace(/\s+/g, "")}-btn`}
+                    id={`${video.id}-btn`}
                     css={{
                       position: "absolute",
                       insetInlineStart: theme.space["050"],
                       insetBlockEnd: theme.space["050"],
                     }}
-                    ref={(ref) => (childRefs.current[index][0] = ref)}
-                    className={
-                      hasFocus(video.headline, "btn") ? focused() : null
-                    }
+                    ref={(el) => {
+                      addDescendant({
+                        element: el,
+                        id: `${video.id}-btn`,
+                        parentId: video.id,
+                      });
+                    }}
                     tabIndex={-1}
                     onClick={() => {
                       console.log("button click");
@@ -571,13 +503,14 @@ const VerticalVideoTemplate = () => {
                       color: theme.colors.gray40,
                       textDecoration: "none",
                     }}
-                    ref={(ref) => (childRefs.current[index][1] = ref)}
-                    id={`${video.headline
-                      .toLowerCase()
-                      .replace(/\s+/g, "")}-link1`}
-                    className={
-                      hasFocus(video.headline, "link1") ? focused() : null
-                    }
+                    ref={(el) => {
+                      addDescendant({
+                        element: el,
+                        id: `${video.id}-link1`,
+                        parentId: video.id,
+                      });
+                    }}
+                    id={`${video.id}-link1`}
                     tabIndex={-1}
                   >
                     {video.headline}
@@ -591,13 +524,14 @@ const VerticalVideoTemplate = () => {
                       fontSize: theme.fontSizes["075"],
                       textDecoration: "none",
                     }}
-                    ref={(ref) => (childRefs.current[index][2] = ref)}
-                    id={`${video.headline
-                      .toLowerCase()
-                      .replace(/\s+/g, "")}-link2`}
-                    className={
-                      hasFocus(video.headline, "link2") ? focused() : null
-                    }
+                    ref={(el) => {
+                      addDescendant({
+                        element: el,
+                        id: `${video.id}-link2`,
+                        parentId: video.id,
+                      });
+                    }}
+                    id={`${video.id}-link2`}
                     tabIndex={-1}
                   >
                     By {video.byline}

--- a/ui/carousel/src/useActiveDescendant.test.tsx
+++ b/ui/carousel/src/useActiveDescendant.test.tsx
@@ -1,0 +1,148 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useActiveDescendant } from "./useActiveDescendant";
+import { CarouselRoot } from "./CarouselRoot";
+import { CarouselContent } from "./CarouselContent";
+import { CarouselItem } from "./CarouselItem";
+
+const ComponentWrapper = ({ onClick }: { onClick?: () => void }) => {
+  const { handleDescendantFocus, contentProps, addDescendant } =
+    useActiveDescendant();
+
+  return (
+    <CarouselRoot onDescendantFocus={handleDescendantFocus}>
+      <CarouselContent {...contentProps}>
+        <CarouselItem id="test-1">
+          <a
+            href="#"
+            tabIndex={-1}
+            id="test-1-link"
+            ref={(el) => {
+              addDescendant({
+                element: el,
+                id: "test-1-link",
+                parentId: "test-1",
+              });
+            }}
+          >
+            Test 1
+          </a>
+          <a
+            href="#"
+            tabIndex={-1}
+            id="test-1-link-2"
+            ref={(el) => {
+              addDescendant({
+                element: el,
+                id: "test-1-link-2",
+                parentId: "test-1",
+              });
+            }}
+          >
+            Test 1.2
+          </a>
+        </CarouselItem>
+        <CarouselItem id="test-2">
+          <button
+            tabIndex={-1}
+            id="test-2-button"
+            ref={(el) => {
+              addDescendant({
+                element: el,
+                id: "test-2-link",
+                parentId: "test-2",
+              });
+            }}
+            onClick={onClick}
+          >
+            Test 2
+          </button>
+        </CarouselItem>
+      </CarouselContent>
+    </CarouselRoot>
+  );
+};
+
+const activeClassname = "wpds-c-cDbbMU";
+
+describe("useActiveDescendant", () => {
+  test("renders visibly into the document", () => {
+    render(<ComponentWrapper />);
+    expect(screen.getByText("Test 1")).toBeVisible();
+  });
+
+  test("uses the down arrow to navigate to child elements", () => {
+    render(<ComponentWrapper />);
+    const groups = screen.getAllByRole("group");
+    const content = groups[1];
+    userEvent.tab();
+    expect(content).toHaveFocus();
+    expect(content).toHaveAttribute("aria-activedescendant", "test-1");
+    userEvent.keyboard("[ArrowDown]");
+    expect(screen.getByText("Test 1")).toHaveClass(activeClassname);
+    expect(content).toHaveAttribute("aria-activedescendant", "test-1-link");
+  });
+
+  test("uses the up arrow to navigate away from child elements", () => {
+    render(<ComponentWrapper />);
+    userEvent.tab();
+    userEvent.keyboard("[ArrowDown]");
+    userEvent.keyboard("[ArrowUp]");
+    expect(screen.getByText("Test 1")).not.toHaveClass(activeClassname);
+  });
+
+  test("uses the up and down arrow to navigate between child elements", () => {
+    render(<ComponentWrapper />);
+    const groups = screen.getAllByRole("group");
+    const content = groups[1];
+    userEvent.tab();
+    userEvent.keyboard("[ArrowDown]");
+    userEvent.keyboard("[ArrowDown]");
+    expect(screen.getByText("Test 1.2")).toHaveClass(activeClassname);
+    expect(content).toHaveAttribute("aria-activedescendant", "test-1-link-2");
+    userEvent.keyboard("[ArrowUp]");
+    expect(screen.getByText("Test 1")).toHaveClass(activeClassname);
+    expect(screen.getByText("Test 1.2")).not.toHaveClass(activeClassname);
+    expect(content).toHaveAttribute("aria-activedescendant", "test-1-link");
+  });
+
+  test("removes active child when new parent becomes active", () => {
+    render(<ComponentWrapper />);
+    const groups = screen.getAllByRole("group");
+    const content = groups[1];
+    userEvent.tab();
+    userEvent.keyboard("[ArrowDown]");
+    userEvent.keyboard("[ArrowRight]");
+    expect(screen.getByText("Test 1")).not.toHaveClass(activeClassname);
+    expect(content).toHaveAttribute("aria-activedescendant", "test-2");
+  });
+
+  test("removes active child when content loses focus", () => {
+    render(<ComponentWrapper />);
+    userEvent.tab();
+    userEvent.keyboard("[ArrowDown]");
+    userEvent.tab();
+    expect(screen.getByText("Test 1")).not.toHaveClass(activeClassname);
+  });
+
+  test("replaces active child when content returns focus", () => {
+    render(<ComponentWrapper />);
+    userEvent.tab();
+    userEvent.keyboard("[ArrowDown]");
+    userEvent.tab();
+    userEvent.tab();
+    expect(screen.getByText("Test 1")).toHaveClass(activeClassname);
+  });
+
+  test("fires child click event from keyboard interaction", () => {
+    const handleClick = jest.fn();
+    render(<ComponentWrapper onClick={handleClick} />);
+    userEvent.tab();
+    userEvent.keyboard("[ArrowRight]");
+    userEvent.keyboard("[ArrowDown]");
+    userEvent.keyboard("[Space]");
+    userEvent.keyboard("[Enter]");
+    expect(handleClick).toHaveBeenCalledTimes(2);
+  });
+});

--- a/ui/carousel/src/useActiveDescendant.ts
+++ b/ui/carousel/src/useActiveDescendant.ts
@@ -47,6 +47,7 @@ export const useActiveDescendant = () => {
 
   function handleDescendantFocus(id) {
     setActiveParentId(id);
+    setDescendantId(id);
     if (activeChildId) {
       const activeParent = tree.current.get(activeParentId);
       const activeChild = activeParent.children.get(activeChildId);

--- a/ui/carousel/src/useActiveDescendant.ts
+++ b/ui/carousel/src/useActiveDescendant.ts
@@ -1,0 +1,203 @@
+/** manage aria-activedescendant */
+import { css, theme } from "@washingtonpost/wpds-theme";
+import { useState, useRef } from "react";
+
+const focused = css({
+  outlineColor: theme.colors.signal,
+  outlineStyle: "solid",
+  outlineWidth: "2px",
+});
+
+type MapEntry = [
+  string,
+  { element: HTMLElement; children?: Map<string, { element: HTMLElement }> }
+];
+
+export const useActiveDescendant = () => {
+  const [descendantId, setDescendantId] = useState<string>();
+  const tree = useRef(new Map());
+  const [activeParentId, setActiveParentId] = useState<string>();
+  const [activeChildId, setActiveChildId] = useState<string>();
+  const focusClassName = focused();
+
+  function addDescendant({
+    element,
+    id,
+    parentId,
+  }: {
+    element: HTMLElement | null;
+    id: string;
+    parentId: string;
+  }) {
+    const data = tree.current;
+    if (element) {
+      if (!data.has(parentId)) {
+        data.set(parentId, { children: new Map() });
+      }
+      const parent = data.get(parentId);
+      parent.children.set(id, { element: element });
+    } else {
+      data.forEach((value) => {
+        if (value.children.has(id)) {
+          value.children.delete(id);
+        }
+      });
+    }
+  }
+
+  function handleDescendantFocus(id) {
+    setActiveParentId(id);
+    if (activeChildId) {
+      const activeParent = tree.current.get(activeParentId);
+      const activeChild = activeParent.children.get(activeChildId);
+      activeChild.element.classList.remove(focusClassName);
+      setActiveChildId(undefined);
+    }
+  }
+
+  function handleFocus() {
+    if (activeChildId) {
+      const activeParent = tree.current.get(activeParentId);
+      const activeChild = activeParent.children.get(activeChildId);
+      activeChild.element.classList.add(focusClassName);
+    }
+  }
+
+  function handleBlur() {
+    if (activeChildId) {
+      const activeParent = tree.current.get(activeParentId);
+      const activeChild = activeParent.children.get(activeChildId);
+      activeChild.element.classList.remove(focusClassName);
+    }
+  }
+
+  function handleKeyDown(event) {
+    let activeParent;
+    let activeChild;
+    let previousChild;
+    let nextChild;
+    let name;
+    switch (event.key) {
+      case "ArrowUp":
+        activeParent = tree.current.get(activeParentId);
+        previousChild = getPreviousSibling(
+          activeChildId,
+          activeParent.children
+        );
+        focusChild(previousChild);
+        event.preventDefault();
+        break;
+      case "ArrowDown":
+        activeParent = tree.current.get(activeParentId);
+        nextChild = getNextSibling(activeChildId, activeParent.children);
+        if (nextChild) {
+          focusChild(nextChild);
+        }
+        event.preventDefault();
+        break;
+      case "Enter":
+        if (activeChildId) {
+          activeParent = tree.current.get(activeParentId);
+          activeChild = activeParent.children.get(activeChildId);
+          name = activeChild.element.nodeName.toLowerCase();
+          if (name === "a" || name === "button") {
+            activeChild.element.click();
+          }
+        }
+        break;
+      default:
+        break;
+    }
+  }
+
+  function handleKeyUp(event) {
+    switch (event.key) {
+      case " ":
+        if (activeChildId) {
+          const activeParent = tree.current.get(activeParentId);
+          const activeChild = activeParent.children.get(activeChildId);
+          const name = activeChild.element.nodeName.toLowerCase();
+          if (name === "button" || name === "input" || name === "select") {
+            activeChild.element.click();
+          }
+        }
+        break;
+      default:
+        break;
+    }
+  }
+
+  function getNextSibling(
+    id: string | undefined,
+    data: Map<string, { element: HTMLElement }> | undefined
+  ) {
+    if (!data) {
+      return;
+    }
+    if (!id) {
+      return data.entries().next().value;
+    }
+    let nextSibling: MapEntry | undefined;
+    let takeNext = false;
+    data.forEach((value, key) => {
+      if (takeNext) {
+        nextSibling = [key, value];
+        takeNext = false;
+      }
+      if (key === id) {
+        takeNext = true;
+      }
+    });
+    return nextSibling;
+  }
+
+  function getPreviousSibling(
+    id: string | undefined,
+    data: Map<string, { element: HTMLElement }> | undefined
+  ) {
+    if (!data) {
+      return;
+    }
+    if (!id) {
+      return;
+    }
+    let previousSibling: MapEntry | undefined;
+    let tempEntry: MapEntry | undefined;
+    data.forEach((value, key) => {
+      if (key === id) {
+        previousSibling = tempEntry;
+      }
+      tempEntry = [key, value];
+    });
+    return previousSibling;
+  }
+
+  function focusChild(entry: MapEntry | undefined) {
+    if (activeChildId) {
+      const activeParent = tree.current.get(activeParentId);
+      const activeChild = activeParent.children.get(activeChildId);
+      activeChild.element.classList.remove(focusClassName);
+    }
+    if (!entry) {
+      // set focus to the parent
+      setDescendantId(activeParentId);
+      setActiveChildId(undefined);
+    } else {
+      setDescendantId(entry[0]);
+      setActiveChildId(entry[0]);
+      entry[1].element.classList.add(focusClassName);
+    }
+  }
+
+  return {
+    addDescendant,
+    handleDescendantFocus,
+    contentProps: {
+      onKeyDown: handleKeyDown,
+      onKeyUp: handleKeyUp,
+      onFocus: handleFocus,
+      onBlur: handleBlur,
+      "aria-activedescendant": descendantId,
+    },
+  };
+};

--- a/ui/theme/src/token-structure.md
+++ b/ui/theme/src/token-structure.md
@@ -1,12 +1,14 @@
-
 # Current Structure
-This map represents our current token mapping structure. Should note that `context` represents the current system context (i.e. dark or light). 
+
+This map represents our current token mapping structure. Should note that `context` represents the current system context (i.e. dark or light).
 
 ### Current supported contexts
+
 - Light
 - Dark
 
 ### Note
+
 Should note that any base context token can be fixed to be the default value of the default context by adding a suffix of `-static`. The default context is light.
 
 ```mermaid
@@ -51,7 +53,7 @@ graph LR;
 
     context---->alpha25;
     context---->alpha50;
-    
+
     context---->gray0
     context---->gray20;
     context---->gray40;
@@ -64,13 +66,13 @@ graph LR;
     context---->gray500;
     context---->gray600;
     context---->gray700;
-   
-    
+
+
 
 
     context---->yellow100;
     context---->yellow600;
-   
+
 
     context---->gold60;
     context---->gold80;
@@ -80,7 +82,7 @@ graph LR;
     context---->gold400;
     context---->gold500;
     context---->gold600;
-   
+
 
     context---->mustard60;
     context---->mustard80;
@@ -90,7 +92,7 @@ graph LR;
     context---->mustard400;
     context---->mustard500;
     context---->mustard600;
-    
+
     context---->orange60;
     context---->orange80;
     context---->orange100;
@@ -99,7 +101,7 @@ graph LR;
     context---->orange400;
     context---->orange500;
     context---->orange600;
-   
+
 
     context---->red60;
     context---->red80;
@@ -109,7 +111,7 @@ graph LR;
     context---->red400;
     context---->red500;
     context---->red600;
-    
+
 
     context---->pink60;
     context---->pink80;
@@ -119,7 +121,7 @@ graph LR;
     context---->pink400;
     context---->pink500;
     context---->pink600;
-   
+
     context---->purple60;
     context---->purple80;
     context---->purple100;
@@ -128,8 +130,8 @@ graph LR;
     context---->purple400;
     context---->purple500;
     context---->purple600;
-   
-    
+
+
     context---->teal60;
     context---->teal80;
     context---->teal100;
@@ -138,7 +140,7 @@ graph LR;
     context---->teal400;
     context---->teal500;
     context---->teal600;
-   
+
 
     context---->green60;
     context---->green80;
@@ -148,7 +150,7 @@ graph LR;
     context---->green400;
     context---->green500;
     context---->green600;
-    
+
 
     context---->blue40;
     context---->blue60;
@@ -159,7 +161,7 @@ graph LR;
     context---->blue400;
     context---->blue500;
     context---->blue600;
-    
+
 
 
 ```


### PR DESCRIPTION
## What I did

This PR adds a custom hook `useActiveDescendant` that helps to manage keyboard navigation and focus for child interactive elements in the Carousel 

```javascript
const { addDescendant, handleDescendantFocus, contentProps } =
    useActiveDescendant();
```
The descendent focus hander is added to the root to monitor the current item with descendant focus
```javascript
<Carousel.Root onDescendantFocus={handleDescendantFocus}>
```
Content props are expanded to pass event handlers and the current `aria-activedescendant` to the content element
```javascript
<Carousel.Content  {...contentProps}>
```
Each CarouselItem must have an id that is then used by its interactive children with the `addDescendant` helper in its ref callback. The interactive child elements must also have an id and have their tabIndex set to -1 to prevent them from stealing focus
```javascript
<Carousel.Item id={item.id}>
  <a
    href="#"
    tabIndex={-1}
    id={`${item.id}-link`}
    ref={(el) => {
      addDescendant({
        element: el,
        id: `${item.id}-link`,
        parentId: item.id,
      });
    }}
  >
  By The Washington Post
  </a>
</Carousel.Item>
```

SRED-289
