### PR TITLE
docs: example of prepopulated search

### DIFF
--- a/build.washingtonpost.com/docs/components/input-search.mdx
+++ b/build.washingtonpost.com/docs/components/input-search.mdx
@@ -1926,6 +1926,65 @@ export default function Example() {
 }
 ```
 
+### Pre populated results
+
+If you have a list of results that you want to show to users, you can pre-populate the results and allow users to search within the results.
+
+```jsx withPreview demoHeight="436" isGuide="information"
+export default function Example() {
+  const suggestions = [
+    "headache",
+    "headlight",
+    "headquarters",
+    "head start",
+    "healer",
+    "health",
+    "health education",
+    "healthy eating habits",
+    "healthy lifestyle",
+    "healing therapies",
+    "heart health",
+    "heartbeat",
+    "heaven",
+    "healthcare provider",
+    "mental health",
+  ];
+
+  const [term, setTerm] = useState("");
+
+  return (
+    <InputSearch.Root aria-label="Example-Search" openOnFocus>
+      <InputSearch.Input
+        name="search"
+        id="search"
+        onChange={(event) => {
+          setTerm(event.target.value);
+        }}
+        label="Search"
+      />
+      <InputSearch.Popover>
+        <InputSearch.List>
+          <InputSearch.ListHeading>
+            Suggestions based on your input
+          </InputSearch.ListHeading>
+          {suggestions
+            .filter((suggestion) =>
+              suggestion.toLowerCase().includes(term.toLowerCase())
+            )
+            .map((suggestion) => (
+              <InputSearch.ListItem
+                key={suggestion}
+                value={suggestion}
+                css={{ cursor: "pointer" }}
+              />
+            ))}
+        </InputSearch.List>
+      </InputSearch.Popover>
+    </InputSearch.Root>
+  );
+}
+```
+
 ---
 
 ## Accessibility

--- a/build.washingtonpost.com/docs/components/input-search.mdx
+++ b/build.washingtonpost.com/docs/components/input-search.mdx
@@ -1926,9 +1926,9 @@ export default function Example() {
 }
 ```
 
-### Pre populated results
+### Pre-populated results
 
-If you have a list of results that you want to show to users, you can pre-populate the results and allow users to search within the results.
+Pre-populate the dropdown when the search is in focus, letting users quickly scan and refine their choice before even searching.
 
 ```jsx withPreview demoHeight="436" isGuide="information"
 export default function Example() {


### PR DESCRIPTION
## What I did

Example is here https://wpds-ui-kit-git-prepopulated-search.preview.now.washingtonpost.com/components/input-search#:~:text=Pre%20populated%20results

<!--
  Explain the **motivation** for making this change. What existing problem does the pull request solve? Please be as detailed as possible.
-->
