### PR TITLE
feat: add `auto` as valid value for Drawer height and width

### DIFF
--- a/ui/drawer/src/DrawerContent.tsx
+++ b/ui/drawer/src/DrawerContent.tsx
@@ -146,7 +146,7 @@ interface DrawerContentProps
   /** Override CSS */
   css?: WPDS.CSS;
   /** Height for a top or bottom positioned drawer  @default 500 */
-  height?: number;
+  height?: number | "auto";
   /** Additional class names for inner drawer element */
   innerClassName?: string;
   /** When `true`, tabbing from last item will focus first tabbable and shift+tab from first item will focus last tababble. @defaultValue true */
@@ -154,7 +154,7 @@ interface DrawerContentProps
   /** When `true`, focus cannot escape the `Content` via keyboard, pointer, or a programmatic focus  @defaultValue false */
   trapFocus?: boolean;
   /** Width for a left or right positioned drawer  @default 400 */
-  width?: number;
+  width?: number | "auto";
 }
 
 export const DrawerContent = React.forwardRef<

--- a/ui/drawer/src/play.stories.tsx
+++ b/ui/drawer/src/play.stories.tsx
@@ -3,6 +3,8 @@ import { screen, userEvent } from "@storybook/testing-library";
 import { expect } from "@storybook/jest";
 import { Drawer as Component } from "./";
 import { theme } from "@washingtonpost/wpds-theme";
+import { Box } from "../../box";
+import { Select } from "../../select";
 
 import type { ComponentMeta, ComponentStory } from "@storybook/react";
 
@@ -130,6 +132,107 @@ const PositionTemplate: ComponentStory<any> = () => (
 
 export const Position = PositionTemplate.bind({});
 Position.parameters = {
+  chromatic: { disableSnapshot: true },
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const AutoSizeTemplate: ComponentStory<any> = () => {
+  const text = [
+    `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+eiusmod tempor incididunt ut labore et dolore magna aliqua. Vestibulum
+morbi blandit cursus risus at ultrices mi. Sit amet facilisis magna
+etiam. Pellentesque pulvinar pellentesque habitant morbi tristique. Id
+faucibus nisl tincidunt eget nullam non nisi. Donec enim diam
+vulputate ut pharetra sit. Accumsan lacus vel facilisis volutpat est
+velit egestas dui. Ullamcorper morbi tincidunt ornare massa eget
+egestas purus viverra. Sed vulputate odio ut enim blandit volutpat
+maecenas. Sed turpis tincidunt id aliquet risus feugiat. Quam
+vulputate dignissim suspendisse in est ante in.`,
+    `Scelerisque viverra mauris in aliquam sem fringilla. Adipiscing
+bibendum est ultricies integer quis auctor elit. Sed elementum tempus
+egestas sed. Purus non enim praesent elementum. Dictum at tempor
+commodo ullamcorper a lacus vestibulum sed arcu. Rhoncus aenean vel
+elit scelerisque mauris pellentesque pulvinar pellentesque habitant.
+Duis at consectetur lorem donec massa sapien faucibus. Viverra
+adipiscing at in tellus integer feugiat scelerisque varius morbi.
+Scelerisque purus semper eget duis at tellus at. Elit at imperdiet dui
+accumsan sit amet. Eu facilisis sed odio morbi quis commodo.`,
+    `Cursus risus at ultrices mi tempus imperdiet. Enim blandit volutpat
+maecenas volutpat blandit aliquam etiam. Urna molestie at elementum eu
+facilisis. At erat pellentesque adipiscing commodo elit at imperdiet
+dui. Sed risus ultricies tristique nulla. Id venenatis a condimentum
+vitae sapien. Eu non diam phasellus vestibulum. Amet tellus cras
+adipiscing enim eu turpis egestas pretium aenean. Sem fringilla ut
+morbi tincidunt augue interdum velit euismod. Eu augue ut lectus arcu
+bibendum. Pellentesque eu tincidunt tortor aliquam nulla. Neque
+aliquam vestibulum morbi blandit. Elementum nisi quis eleifend quam
+adipiscing vitae proin sagittis. Eget egestas purus viverra accumsan
+in nisl nisi scelerisque eu. Aenean euismod elementum nisi quis
+eleifend quam adipiscing vitae. Euismod in pellentesque massa placerat
+duis. Dui sapien eget mi proin sed libero enim. Suspendisse potenti
+nullam ac tortor vitae purus.`,
+    `Velit egestas dui id ornare arcu odio ut. Sagittis id consectetur
+purus ut faucibus pulvinar elementum integer enim. Mauris in aliquam
+sem fringilla ut. Commodo viverra maecenas accumsan lacus vel
+facilisis volutpat est velit. Proin nibh nisl condimentum id venenatis
+a condimentum vitae sapien. Velit egestas dui id ornare arcu. Eu augue
+ut lectus arcu. Molestie nunc non blandit massa. Amet risus nullam
+eget felis eget nunc. Non tellus orci ac auctor augue mauris augue
+neque gravida. Feugiat in ante metus dictum at. Nec tincidunt praesent
+semper feugiat. Ridiculus mus mauris vitae ultricies leo integer
+malesuada. Scelerisque in dictum non consectetur a erat. Eget sit amet
+tellus cras adipiscing enim eu.`,
+    `Vel quam elementum pulvinar etiam non quam lacus suspendisse. Id velit
+ut tortor pretium viverra. Integer malesuada nunc vel risus commodo
+viverra maecenas. Ligula ullamcorper malesuada proin libero nunc
+consequat interdum. Senectus et netus et malesuada fames ac turpis
+egestas maecenas. Lacus viverra vitae congue eu consequat. Gravida
+neque convallis a cras. Enim eu turpis egestas pretium. Fringilla ut
+morbi tincidunt augue interdum velit euismod in pellentesque. Id
+faucibus nisl tincidunt eget nullam non nisi est sit. Sem et tortor
+consequat id. Nunc sed velit dignissim sodales ut eu. Egestas egestas
+fringilla phasellus faucibus scelerisque eleifend donec. Aliquet
+porttitor lacus luctus accumsan. Orci ac auctor augue mauris augue
+neque gravida in fermentum.`,
+  ];
+  const [textLength, setTextLength] = React.useState(5);
+  return (
+    <Component.Root id="interaction-drawer">
+      <Component.Trigger css={{ marginBottom: "$050" }}>
+        Open Drawer
+      </Component.Trigger>
+      <Box css={{ width: "180px" }}>
+        <Select.Root
+          value={String(textLength)}
+          onValueChange={(val) => setTextLength(parseInt(val, 10))}
+        >
+          <Select.Trigger aria-label="example-2">
+            <Select.Label>Number of paragraphs</Select.Label>
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Content>
+            <Select.Item value="1">1</Select.Item>
+            <Select.Item value="2">2</Select.Item>
+            <Select.Item value="3">3</Select.Item>
+            <Select.Item value="4">4</Select.Item>
+            <Select.Item value="5">5</Select.Item>
+          </Select.Content>
+        </Select.Root>
+      </Box>
+
+      <Component.Content height="auto" position="bottom">
+        <Component.Close />
+        {text.slice(0, textLength).map((currentText, index) => (
+          <p key={`p-${index}`}>{currentText}</p>
+        ))}
+      </Component.Content>
+      <Component.Scrim />
+    </Component.Root>
+  );
+};
+
+export const AutoSize = AutoSizeTemplate.bind({});
+AutoSize.parameters = {
   chromatic: { disableSnapshot: true },
 };
 


### PR DESCRIPTION
## What I did

This PR expands the accepted values of the `width` and `height` attributes of the drawer to include `auto` as a value. Allowing the Drawer to dynamically resize based on its content.

SRED-418
