### PR TITLE
chore: reformat edited files to allow for successful deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,36 +5,24 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [1.13.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.12.0...v1.13.0) (2023-09-18)
 
-
 ### Bug Fixes
 
-* Floating select label SRED-446 ([#501](https://github.com/washingtonpost/wpds-ui-kit/issues/501)) ([c71efa2](https://github.com/washingtonpost/wpds-ui-kit/commit/c71efa29a1c32227251ad3bfa1dbddc6c450d9f4))
-
+- Floating select label SRED-446 ([#501](https://github.com/washingtonpost/wpds-ui-kit/issues/501)) ([c71efa2](https://github.com/washingtonpost/wpds-ui-kit/commit/c71efa29a1c32227251ad3bfa1dbddc6c450d9f4))
 
 ### Features
 
-* rewrite component status page [SRED-404] ([#497](https://github.com/washingtonpost/wpds-ui-kit/issues/497)) ([920361b](https://github.com/washingtonpost/wpds-ui-kit/commit/920361bd20a16cf543d036108aec516c800ffb67))
-
-
-
-
+- rewrite component status page [SRED-404] ([#497](https://github.com/washingtonpost/wpds-ui-kit/issues/497)) ([920361b](https://github.com/washingtonpost/wpds-ui-kit/commit/920361bd20a16cf543d036108aec516c800ffb67))
 
 # [1.12.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
-
 ### Bug Fixes
 
-* set root to be category of each ([#488](https://github.com/washingtonpost/wpds-ui-kit/issues/488)) ([c661f4b](https://github.com/washingtonpost/wpds-ui-kit/commit/c661f4beaa65f750bd83f66a232c030e6ba61565))
-
+- set root to be category of each ([#488](https://github.com/washingtonpost/wpds-ui-kit/issues/488)) ([c661f4b](https://github.com/washingtonpost/wpds-ui-kit/commit/c661f4beaa65f750bd83f66a232c030e6ba61565))
 
 ### Features
 
-* adding Support to sidebar nav ([#498](https://github.com/washingtonpost/wpds-ui-kit/issues/498)) ([78a274b](https://github.com/washingtonpost/wpds-ui-kit/commit/78a274b07290a939c252a4c02d6350e4e2096821))
-* move switch to stable ([#496](https://github.com/washingtonpost/wpds-ui-kit/issues/496)) ([91188e7](https://github.com/washingtonpost/wpds-ui-kit/commit/91188e7ea6fdd5be900cf0612516c9086a13a91b))
-
-
-
-
+- adding Support to sidebar nav ([#498](https://github.com/washingtonpost/wpds-ui-kit/issues/498)) ([78a274b](https://github.com/washingtonpost/wpds-ui-kit/commit/78a274b07290a939c252a4c02d6350e4e2096821))
+- move switch to stable ([#496](https://github.com/washingtonpost/wpds-ui-kit/issues/496)) ([91188e7](https://github.com/washingtonpost/wpds-ui-kit/commit/91188e7ea6fdd5be900cf0612516c9086a13a91b))
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/apps/vite-project/CHANGELOG.md
+++ b/apps/vite-project/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package vite-project
 
-
-
-
-
 # [1.12.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package vite-project
-
-
-
-
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/apps/vite-v2-project/CHANGELOG.md
+++ b/apps/vite-v2-project/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package vite-v2-project
 
-
-
-
-
 # [1.12.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package vite-v2-project
-
-
-
-
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/build.washingtonpost.com/CHANGELOG.md
+++ b/build.washingtonpost.com/CHANGELOG.md
@@ -5,31 +5,20 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [1.13.0](https://github.com/washingtonpost/wpds-docs/compare/v1.12.0...v1.13.0) (2023-09-18)
 
-
 ### Features
 
-* rewrite component status page [SRED-404] ([#497](https://github.com/washingtonpost/wpds-docs/issues/497)) ([920361b](https://github.com/washingtonpost/wpds-docs/commit/920361bd20a16cf543d036108aec516c800ffb67))
-
-
-
-
+- rewrite component status page [SRED-404] ([#497](https://github.com/washingtonpost/wpds-docs/issues/497)) ([920361b](https://github.com/washingtonpost/wpds-docs/commit/920361bd20a16cf543d036108aec516c800ffb67))
 
 # [1.12.0](https://github.com/washingtonpost/wpds-docs/compare/v1.11.1...v1.12.0) (2023-09-13)
 
-
 ### Bug Fixes
 
-* set root to be category of each ([#488](https://github.com/washingtonpost/wpds-docs/issues/488)) ([c661f4b](https://github.com/washingtonpost/wpds-docs/commit/c661f4beaa65f750bd83f66a232c030e6ba61565))
-
+- set root to be category of each ([#488](https://github.com/washingtonpost/wpds-docs/issues/488)) ([c661f4b](https://github.com/washingtonpost/wpds-docs/commit/c661f4beaa65f750bd83f66a232c030e6ba61565))
 
 ### Features
 
-* adding Support to sidebar nav ([#498](https://github.com/washingtonpost/wpds-docs/issues/498)) ([78a274b](https://github.com/washingtonpost/wpds-docs/commit/78a274b07290a939c252a4c02d6350e4e2096821))
-* move switch to stable ([#496](https://github.com/washingtonpost/wpds-docs/issues/496)) ([91188e7](https://github.com/washingtonpost/wpds-docs/commit/91188e7ea6fdd5be900cf0612516c9086a13a91b))
-
-
-
-
+- adding Support to sidebar nav ([#498](https://github.com/washingtonpost/wpds-docs/issues/498)) ([78a274b](https://github.com/washingtonpost/wpds-docs/commit/78a274b07290a939c252a4c02d6350e4e2096821))
+- move switch to stable ([#496](https://github.com/washingtonpost/wpds-docs/issues/496)) ([91188e7](https://github.com/washingtonpost/wpds-docs/commit/91188e7ea6fdd5be900cf0612516c9086a13a91b))
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-docs/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/build.washingtonpost.com/components/ComponentPage/ComponentStatus.jsx
+++ b/build.washingtonpost.com/components/ComponentPage/ComponentStatus.jsx
@@ -7,9 +7,10 @@ export const ComponentStatus = ({ type }) => {
 
   const alphaContent = (
     <>
-      <b>Alpha: </b>This status indicates that the component is available via code, but BREAKING CHANGES 
-can be expected and the documentation is still in refinement. That would mean that guidance 
-can change, code examples might change and content can be corrected, rephrased and/or removed.
+      <b>Alpha: </b>This status indicates that the component is available via
+      code, but BREAKING CHANGES can be expected and the documentation is still
+      in refinement. That would mean that guidance can change, code examples
+      might change and content can be corrected, rephrased and/or removed.
     </>
   );
 
@@ -17,9 +18,10 @@ can change, code examples might change and content can be corrected, rephrased a
 
   const betaContent = (
     <>
-      <b>Beta: </b>This status indicates that the component design + documentation is finalized and
-it is available via code. Additive changes may still occur but no breaking changes 
-will occur unless a security fix is needed.
+      <b>Beta: </b>This status indicates that the component design +
+      documentation is finalized and it is available via code. Additive changes
+      may still occur but no breaking changes will occur unless a security fix
+      is needed.
     </>
   );
 

--- a/build.washingtonpost.com/docs/support/component-status.mdx
+++ b/build.washingtonpost.com/docs/support/component-status.mdx
@@ -18,8 +18,8 @@ is currently under development. This status only appears on the sidebar of our n
   <Change type="Alpha">Alpha</Change>
 </Box>
 
-This status indicates that the component is available via code, but BREAKING CHANGES 
-can be expected and the documentation is still in refinement. That would mean that guidance 
+This status indicates that the component is available via code, but BREAKING CHANGES
+can be expected and the documentation is still in refinement. That would mean that guidance
 can change, code examples might change and content can be corrected, rephrased and/or removed.
 
 This status will appear as a banner on the component documentation page.
@@ -31,8 +31,8 @@ This status will appear as a banner on the component documentation page.
 </Box>
 
 This status indicates that the component design + documentation is finalized and
-it is available via code. Additive changes may still occur but no breaking changes 
-will occur unless a security fix is needed. 
+it is available via code. Additive changes may still occur but no breaking changes
+will occur unless a security fix is needed.
 
 This status will appear as a banner on the component documentation page.
 
@@ -42,4 +42,3 @@ This status will appear as a banner on the component documentation page.
 
 If no status is shown on the component it indicates the component has reached a stable state.
 Any changes that occur to the component will be communicated far ahead of their implementation.
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -111,10 +111,10 @@
       }
     },
     "apps/vite-project": {
-      "version": "1.12.0",
+      "version": "1.13.0",
       "dependencies": {
-        "@washingtonpost/wpds-kitchen-sink": "1.12.0",
-        "@washingtonpost/wpds-ui-kit": "1.12.0",
+        "@washingtonpost/wpds-kitchen-sink": "1.13.0",
+        "@washingtonpost/wpds-ui-kit": "1.13.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -172,10 +172,10 @@
       }
     },
     "apps/vite-v2-project": {
-      "version": "1.12.0",
+      "version": "1.13.0",
       "dependencies": {
-        "@washingtonpost/wpds-kitchen-sink": "1.12.0",
-        "@washingtonpost/wpds-ui-kit": "1.12.0",
+        "@washingtonpost/wpds-kitchen-sink": "1.13.0",
+        "@washingtonpost/wpds-ui-kit": "1.13.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
       },
@@ -678,7 +678,7 @@
     },
     "build.washingtonpost.com": {
       "name": "@washingtonpost/wpds-docs",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/standalone": "^7.17.11",
@@ -692,11 +692,11 @@
         "@stitches/react": "1.2.8",
         "@washingtonpost/site-favicons": "^0.1.3",
         "@washingtonpost/tachyons-css": "^1.8.0",
-        "@washingtonpost/wpds-accordion": "1.12.0",
+        "@washingtonpost/wpds-accordion": "1.13.0",
         "@washingtonpost/wpds-assets": "1.22.0",
-        "@washingtonpost/wpds-kitchen-sink": "1.12.0",
-        "@washingtonpost/wpds-tailwind-theme": "1.12.0",
-        "@washingtonpost/wpds-ui-kit": "1.12.0",
+        "@washingtonpost/wpds-kitchen-sink": "1.13.0",
+        "@washingtonpost/wpds-tailwind-theme": "1.13.0",
+        "@washingtonpost/wpds-ui-kit": "1.13.0",
         "fuse.js": "^6.6.2",
         "gray-matter": "^4.0.2",
         "lz-string": "^1.4.4",
@@ -48950,13 +48950,13 @@
     },
     "ui/accordion": {
       "name": "@washingtonpost/wpds-accordion",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-accordion": "^1.1.0",
         "@washingtonpost/wpds-assets": "^1.22.0",
-        "@washingtonpost/wpds-icon": "1.12.0",
-        "@washingtonpost/wpds-theme": "1.12.0"
+        "@washingtonpost/wpds-icon": "1.13.0",
+        "@washingtonpost/wpds-theme": "1.13.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -49047,15 +49047,15 @@
     },
     "ui/action-menu": {
       "name": "@washingtonpost/wpds-action-menu",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-dropdown-menu": "2.0.3",
         "@washingtonpost/wpds-assets": "^1.20.0",
-        "@washingtonpost/wpds-button": "1.12.0",
-        "@washingtonpost/wpds-divider": "1.12.0",
-        "@washingtonpost/wpds-icon": "1.12.0",
-        "@washingtonpost/wpds-theme": "1.12.0"
+        "@washingtonpost/wpds-button": "1.13.0",
+        "@washingtonpost/wpds-divider": "1.13.0",
+        "@washingtonpost/wpds-icon": "1.13.0",
+        "@washingtonpost/wpds-theme": "1.13.0"
       },
       "devDependencies": {
         "@types/node": "^20.4.2",
@@ -49078,15 +49078,15 @@
     },
     "ui/alert-banner": {
       "name": "@washingtonpost/wpds-alert-banner",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-app-bar": "1.12.0",
+        "@washingtonpost/wpds-app-bar": "1.13.0",
         "@washingtonpost/wpds-assets": "^1.22.0",
-        "@washingtonpost/wpds-button": "1.12.0",
-        "@washingtonpost/wpds-container": "1.12.0",
-        "@washingtonpost/wpds-icon": "1.12.0",
-        "@washingtonpost/wpds-theme": "1.12.0",
+        "@washingtonpost/wpds-button": "1.13.0",
+        "@washingtonpost/wpds-container": "1.13.0",
+        "@washingtonpost/wpds-icon": "1.13.0",
+        "@washingtonpost/wpds-theme": "1.13.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {
@@ -49117,10 +49117,10 @@
     },
     "ui/app-bar": {
       "name": "@washingtonpost/wpds-app-bar",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.12.0",
+        "@washingtonpost/wpds-theme": "1.13.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {
@@ -49134,11 +49134,11 @@
     },
     "ui/avatar": {
       "name": "@washingtonpost/wpds-avatar",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-avatar": "latest",
-        "@washingtonpost/wpds-theme": "1.12.0"
+        "@washingtonpost/wpds-theme": "1.13.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -49167,10 +49167,10 @@
     },
     "ui/box": {
       "name": "@washingtonpost/wpds-box",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.12.0",
+        "@washingtonpost/wpds-theme": "1.13.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {
@@ -49184,10 +49184,10 @@
     },
     "ui/button": {
       "name": "@washingtonpost/wpds-button",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.12.0",
+        "@washingtonpost/wpds-theme": "1.13.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {
@@ -49201,10 +49201,10 @@
     },
     "ui/card": {
       "name": "@washingtonpost/wpds-card",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.12.0"
+        "@washingtonpost/wpds-theme": "1.13.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -49217,16 +49217,16 @@
     },
     "ui/carousel": {
       "name": "@washingtonpost/wpds-carousel",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "^1.0.0",
         "@radix-ui/react-use-controllable-state": "^1.0.0",
         "@washingtonpost/wpds-assets": "^1.22.0",
-        "@washingtonpost/wpds-button": "1.12.0",
-        "@washingtonpost/wpds-icon": "1.12.0",
-        "@washingtonpost/wpds-pagination-dots": "1.12.0",
-        "@washingtonpost/wpds-theme": "1.12.0",
+        "@washingtonpost/wpds-button": "1.13.0",
+        "@washingtonpost/wpds-icon": "1.13.0",
+        "@washingtonpost/wpds-pagination-dots": "1.13.0",
+        "@washingtonpost/wpds-theme": "1.13.0",
         "nanoid": "^3.3.4",
         "react-swipeable": "^7.0.0"
       },
@@ -49245,16 +49245,16 @@
     },
     "ui/checkbox": {
       "name": "@washingtonpost/wpds-checkbox",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.0.0",
         "@washingtonpost/wpds-assets": "^1.22.0",
-        "@washingtonpost/wpds-icon": "1.12.0",
-        "@washingtonpost/wpds-input-label": "1.12.0",
-        "@washingtonpost/wpds-input-shared": "1.12.0",
-        "@washingtonpost/wpds-theme": "1.12.0",
-        "@washingtonpost/wpds-visually-hidden": "1.12.0",
+        "@washingtonpost/wpds-icon": "1.13.0",
+        "@washingtonpost/wpds-input-label": "1.13.0",
+        "@washingtonpost/wpds-input-shared": "1.13.0",
+        "@washingtonpost/wpds-theme": "1.13.0",
+        "@washingtonpost/wpds-visually-hidden": "1.13.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {
@@ -49328,10 +49328,10 @@
     },
     "ui/container": {
       "name": "@washingtonpost/wpds-container",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.12.0",
+        "@washingtonpost/wpds-theme": "1.13.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {
@@ -49345,11 +49345,11 @@
     },
     "ui/divider": {
       "name": "@washingtonpost/wpds-divider",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-separator": "^1.0.0",
-        "@washingtonpost/wpds-theme": "1.12.0"
+        "@washingtonpost/wpds-theme": "1.13.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -49386,15 +49386,15 @@
     },
     "ui/drawer": {
       "name": "@washingtonpost/wpds-drawer",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-focus-scope": "^1.0.0",
         "@washingtonpost/wpds-assets": "^1.22.0",
-        "@washingtonpost/wpds-button": "1.12.0",
-        "@washingtonpost/wpds-icon": "1.12.0",
-        "@washingtonpost/wpds-scrim": "1.12.0",
-        "@washingtonpost/wpds-theme": "1.12.0",
+        "@washingtonpost/wpds-button": "1.13.0",
+        "@washingtonpost/wpds-icon": "1.13.0",
+        "@washingtonpost/wpds-scrim": "1.13.0",
+        "@washingtonpost/wpds-theme": "1.13.0",
         "react-transition-group": "^4.4.5"
       },
       "devDependencies": {
@@ -49424,10 +49424,10 @@
     },
     "ui/error-message": {
       "name": "@washingtonpost/wpds-error-message",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.12.0"
+        "@washingtonpost/wpds-theme": "1.13.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -49440,10 +49440,10 @@
     },
     "ui/eslint-plugin": {
       "name": "@washingtonpost/eslint-plugin-wpds",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.12.0"
+        "@washingtonpost/wpds-theme": "1.13.0"
       },
       "devDependencies": {
         "jest": "^28.1.0"
@@ -49454,10 +49454,10 @@
     },
     "ui/fieldset": {
       "name": "@washingtonpost/wpds-fieldset",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.12.0"
+        "@washingtonpost/wpds-theme": "1.13.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -49470,10 +49470,10 @@
     },
     "ui/helper-text": {
       "name": "@washingtonpost/wpds-helper-text",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.12.0"
+        "@washingtonpost/wpds-theme": "1.13.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -49486,11 +49486,11 @@
     },
     "ui/icon": {
       "name": "@washingtonpost/wpds-icon",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.12.0",
-        "@washingtonpost/wpds-visually-hidden": "1.12.0",
+        "@washingtonpost/wpds-theme": "1.13.0",
+        "@washingtonpost/wpds-visually-hidden": "1.13.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {
@@ -49505,12 +49505,12 @@
     },
     "ui/input-label": {
       "name": "@washingtonpost/wpds-input-label",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-label": "^1.0.0",
-        "@washingtonpost/wpds-input-shared": "1.12.0",
-        "@washingtonpost/wpds-theme": "1.12.0"
+        "@washingtonpost/wpds-input-shared": "1.13.0",
+        "@washingtonpost/wpds-theme": "1.13.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -49524,12 +49524,12 @@
     },
     "ui/input-password": {
       "name": "@washingtonpost/wpds-input-password",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@washingtonpost/wpds-assets": "^1.22.0",
-        "@washingtonpost/wpds-icon": "1.12.0",
-        "@washingtonpost/wpds-input-text": "1.12.0"
+        "@washingtonpost/wpds-icon": "1.13.0",
+        "@washingtonpost/wpds-input-text": "1.13.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -49556,16 +49556,16 @@
     },
     "ui/input-search": {
       "name": "@washingtonpost/wpds-input-search",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@reach/combobox": "^0.18.0",
         "@reach/popover": "^0.18.0",
         "@washingtonpost/wpds-assets": "^1.22.0",
-        "@washingtonpost/wpds-icon": "1.12.0",
-        "@washingtonpost/wpds-input-label": "1.12.0",
-        "@washingtonpost/wpds-input-text": "1.12.0",
-        "@washingtonpost/wpds-theme": "1.12.0",
+        "@washingtonpost/wpds-icon": "1.13.0",
+        "@washingtonpost/wpds-input-label": "1.13.0",
+        "@washingtonpost/wpds-input-text": "1.13.0",
+        "@washingtonpost/wpds-theme": "1.13.0",
         "match-sorter": "6.3.1"
       },
       "devDependencies": {
@@ -49583,10 +49583,10 @@
     },
     "ui/input-shared": {
       "name": "@washingtonpost/wpds-input-shared",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.12.0"
+        "@washingtonpost/wpds-theme": "1.13.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -49599,19 +49599,19 @@
     },
     "ui/input-text": {
       "name": "@washingtonpost/wpds-input-text",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-label": "^1.0.0",
         "@washingtonpost/wpds-assets": "^1.22.0",
-        "@washingtonpost/wpds-button": "1.12.0",
-        "@washingtonpost/wpds-error-message": "1.12.0",
-        "@washingtonpost/wpds-helper-text": "1.12.0",
-        "@washingtonpost/wpds-icon": "1.12.0",
-        "@washingtonpost/wpds-input-label": "1.12.0",
-        "@washingtonpost/wpds-input-shared": "1.12.0",
-        "@washingtonpost/wpds-theme": "1.12.0",
-        "@washingtonpost/wpds-visually-hidden": "1.12.0",
+        "@washingtonpost/wpds-button": "1.13.0",
+        "@washingtonpost/wpds-error-message": "1.13.0",
+        "@washingtonpost/wpds-helper-text": "1.13.0",
+        "@washingtonpost/wpds-icon": "1.13.0",
+        "@washingtonpost/wpds-input-label": "1.13.0",
+        "@washingtonpost/wpds-input-shared": "1.13.0",
+        "@washingtonpost/wpds-theme": "1.13.0",
+        "@washingtonpost/wpds-visually-hidden": "1.13.0",
         "nanoid": "^3.3.4"
       },
       "devDependencies": {
@@ -49656,14 +49656,14 @@
     },
     "ui/input-textarea": {
       "name": "@washingtonpost/wpds-input-textarea",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-error-message": "1.12.0",
-        "@washingtonpost/wpds-helper-text": "1.12.0",
-        "@washingtonpost/wpds-input-label": "1.12.0",
-        "@washingtonpost/wpds-input-shared": "1.12.0",
-        "@washingtonpost/wpds-theme": "1.12.0",
+        "@washingtonpost/wpds-error-message": "1.13.0",
+        "@washingtonpost/wpds-helper-text": "1.13.0",
+        "@washingtonpost/wpds-input-label": "1.13.0",
+        "@washingtonpost/wpds-input-shared": "1.13.0",
+        "@washingtonpost/wpds-theme": "1.13.0",
         "nanoid": "^3.3.4",
         "react": "^16.8.6 || ^17.0.2"
       },
@@ -49682,44 +49682,44 @@
     },
     "ui/kit": {
       "name": "@washingtonpost/wpds-ui-kit",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/eslint-plugin-wpds": "1.12.0",
-        "@washingtonpost/wpds-accordion": "1.12.0",
-        "@washingtonpost/wpds-action-menu": "1.12.0",
-        "@washingtonpost/wpds-alert-banner": "1.12.0",
-        "@washingtonpost/wpds-app-bar": "1.12.0",
-        "@washingtonpost/wpds-avatar": "1.12.0",
-        "@washingtonpost/wpds-box": "1.12.0",
-        "@washingtonpost/wpds-button": "1.12.0",
-        "@washingtonpost/wpds-card": "1.12.0",
-        "@washingtonpost/wpds-carousel": "1.12.0",
-        "@washingtonpost/wpds-checkbox": "1.12.0",
-        "@washingtonpost/wpds-container": "1.12.0",
-        "@washingtonpost/wpds-divider": "1.12.0",
-        "@washingtonpost/wpds-drawer": "1.12.0",
-        "@washingtonpost/wpds-error-message": "1.12.0",
-        "@washingtonpost/wpds-fieldset": "1.12.0",
-        "@washingtonpost/wpds-helper-text": "1.12.0",
-        "@washingtonpost/wpds-icon": "1.12.0",
-        "@washingtonpost/wpds-input-label": "1.12.0",
-        "@washingtonpost/wpds-input-password": "1.12.0",
-        "@washingtonpost/wpds-input-search": "1.12.0",
-        "@washingtonpost/wpds-input-shared": "1.12.0",
-        "@washingtonpost/wpds-input-text": "1.12.0",
-        "@washingtonpost/wpds-input-textarea": "1.12.0",
-        "@washingtonpost/wpds-navigation-menu": "1.12.0",
-        "@washingtonpost/wpds-pagination-dots": "1.12.0",
-        "@washingtonpost/wpds-popover": "1.12.0",
-        "@washingtonpost/wpds-radio-group": "1.12.0",
-        "@washingtonpost/wpds-scrim": "1.12.0",
-        "@washingtonpost/wpds-select": "1.12.0",
-        "@washingtonpost/wpds-switch": "1.12.0",
-        "@washingtonpost/wpds-tabs": "1.12.0",
-        "@washingtonpost/wpds-theme": "1.12.0",
-        "@washingtonpost/wpds-tooltip": "1.12.0",
-        "@washingtonpost/wpds-visually-hidden": "1.12.0"
+        "@washingtonpost/eslint-plugin-wpds": "1.13.0",
+        "@washingtonpost/wpds-accordion": "1.13.0",
+        "@washingtonpost/wpds-action-menu": "1.13.0",
+        "@washingtonpost/wpds-alert-banner": "1.13.0",
+        "@washingtonpost/wpds-app-bar": "1.13.0",
+        "@washingtonpost/wpds-avatar": "1.13.0",
+        "@washingtonpost/wpds-box": "1.13.0",
+        "@washingtonpost/wpds-button": "1.13.0",
+        "@washingtonpost/wpds-card": "1.13.0",
+        "@washingtonpost/wpds-carousel": "1.13.0",
+        "@washingtonpost/wpds-checkbox": "1.13.0",
+        "@washingtonpost/wpds-container": "1.13.0",
+        "@washingtonpost/wpds-divider": "1.13.0",
+        "@washingtonpost/wpds-drawer": "1.13.0",
+        "@washingtonpost/wpds-error-message": "1.13.0",
+        "@washingtonpost/wpds-fieldset": "1.13.0",
+        "@washingtonpost/wpds-helper-text": "1.13.0",
+        "@washingtonpost/wpds-icon": "1.13.0",
+        "@washingtonpost/wpds-input-label": "1.13.0",
+        "@washingtonpost/wpds-input-password": "1.13.0",
+        "@washingtonpost/wpds-input-search": "1.13.0",
+        "@washingtonpost/wpds-input-shared": "1.13.0",
+        "@washingtonpost/wpds-input-text": "1.13.0",
+        "@washingtonpost/wpds-input-textarea": "1.13.0",
+        "@washingtonpost/wpds-navigation-menu": "1.13.0",
+        "@washingtonpost/wpds-pagination-dots": "1.13.0",
+        "@washingtonpost/wpds-popover": "1.13.0",
+        "@washingtonpost/wpds-radio-group": "1.13.0",
+        "@washingtonpost/wpds-scrim": "1.13.0",
+        "@washingtonpost/wpds-select": "1.13.0",
+        "@washingtonpost/wpds-switch": "1.13.0",
+        "@washingtonpost/wpds-tabs": "1.13.0",
+        "@washingtonpost/wpds-theme": "1.13.0",
+        "@washingtonpost/wpds-tooltip": "1.13.0",
+        "@washingtonpost/wpds-visually-hidden": "1.13.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -49765,11 +49765,11 @@
     },
     "ui/kitchen-sink": {
       "name": "@washingtonpost/wpds-kitchen-sink",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@washingtonpost/wpds-assets": "latest",
-        "@washingtonpost/wpds-ui-kit": "1.12.0",
+        "@washingtonpost/wpds-ui-kit": "1.13.0",
         "nanoid": "^3.3.4"
       },
       "devDependencies": {
@@ -49784,12 +49784,12 @@
     },
     "ui/navigation-menu": {
       "name": "@washingtonpost/wpds-navigation-menu",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.7",
         "@radix-ui/react-navigation-menu": "^1.1.2",
-        "@washingtonpost/wpds-theme": "1.12.0",
+        "@washingtonpost/wpds-theme": "1.13.0",
         "popper-max-size-modifier": "^0.2.0",
         "react-popper": "^2.3.0",
         "react-transition-group": "^4.4.5"
@@ -49805,10 +49805,10 @@
     },
     "ui/pagination-dots": {
       "name": "@washingtonpost/wpds-pagination-dots",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.12.0"
+        "@washingtonpost/wpds-theme": "1.13.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -49821,14 +49821,14 @@
     },
     "ui/popover": {
       "name": "@washingtonpost/wpds-popover",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-popover": "^1.0.2",
         "@washingtonpost/wpds-assets": "^1.22.0",
-        "@washingtonpost/wpds-button": "1.12.0",
-        "@washingtonpost/wpds-icon": "1.12.0",
-        "@washingtonpost/wpds-theme": "1.12.0"
+        "@washingtonpost/wpds-button": "1.13.0",
+        "@washingtonpost/wpds-icon": "1.13.0",
+        "@washingtonpost/wpds-theme": "1.13.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -49841,14 +49841,14 @@
     },
     "ui/radio-group": {
       "name": "@washingtonpost/wpds-radio-group",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-radio-group": "^1.0.0",
-        "@washingtonpost/wpds-error-message": "1.12.0",
-        "@washingtonpost/wpds-fieldset": "1.12.0",
-        "@washingtonpost/wpds-input-label": "1.12.0",
-        "@washingtonpost/wpds-theme": "1.12.0",
+        "@washingtonpost/wpds-error-message": "1.13.0",
+        "@washingtonpost/wpds-fieldset": "1.13.0",
+        "@washingtonpost/wpds-input-label": "1.13.0",
+        "@washingtonpost/wpds-theme": "1.13.0",
         "nanoid": "^3.3.3"
       },
       "devDependencies": {
@@ -49944,11 +49944,11 @@
     },
     "ui/scrim": {
       "name": "@washingtonpost/wpds-scrim",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.0.0",
-        "@washingtonpost/wpds-theme": "1.12.0",
+        "@washingtonpost/wpds-theme": "1.13.0",
         "react-transition-group": "^4.4.5"
       },
       "devDependencies": {
@@ -49962,17 +49962,17 @@
     },
     "ui/select": {
       "name": "@washingtonpost/wpds-select",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-select": "^1.2.2",
         "@radix-ui/react-use-controllable-state": "^1.0.0",
         "@washingtonpost/wpds-assets": "^1.22.0",
-        "@washingtonpost/wpds-divider": "1.12.0",
-        "@washingtonpost/wpds-icon": "1.12.0",
-        "@washingtonpost/wpds-input-label": "1.12.0",
-        "@washingtonpost/wpds-input-shared": "1.12.0",
-        "@washingtonpost/wpds-theme": "1.12.0",
+        "@washingtonpost/wpds-divider": "1.13.0",
+        "@washingtonpost/wpds-icon": "1.13.0",
+        "@washingtonpost/wpds-input-label": "1.13.0",
+        "@washingtonpost/wpds-input-shared": "1.13.0",
+        "@washingtonpost/wpds-theme": "1.13.0",
         "nanoid": "^3.3.4"
       },
       "devDependencies": {
@@ -50010,11 +50010,11 @@
     },
     "ui/switch": {
       "name": "@washingtonpost/wpds-switch",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-switch": "^1.0.1",
-        "@washingtonpost/wpds-theme": "1.12.0"
+        "@washingtonpost/wpds-theme": "1.13.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -50027,15 +50027,15 @@
     },
     "ui/tabs": {
       "name": "@washingtonpost/wpds-tabs",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "^1.0.2",
         "@radix-ui/react-tabs": "latest",
         "@washingtonpost/wpds-assets": "^1.22.0",
         "@washingtonpost/wpds-icon": "1.1.0",
-        "@washingtonpost/wpds-theme": "1.12.0",
-        "@washingtonpost/wpds-tooltip": "1.12.0",
+        "@washingtonpost/wpds-theme": "1.13.0",
+        "@washingtonpost/wpds-tooltip": "1.13.0",
         "react-transition-group": "^4.4.5"
       },
       "devDependencies": {
@@ -50147,10 +50147,10 @@
     },
     "ui/tailwind-theme": {
       "name": "@washingtonpost/wpds-tailwind-theme",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.12.0"
+        "@washingtonpost/wpds-theme": "1.13.0"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.14",
@@ -50376,7 +50376,7 @@
     },
     "ui/theme": {
       "name": "@washingtonpost/wpds-theme",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@stitches/react": "^1.2.8"
@@ -50388,11 +50388,11 @@
     },
     "ui/tooltip": {
       "name": "@washingtonpost/wpds-tooltip",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-tooltip": "^1.0.0",
-        "@washingtonpost/wpds-theme": "1.12.0"
+        "@washingtonpost/wpds-theme": "1.13.0"
       },
       "devDependencies": {
         "tsup": "5.11.13",
@@ -50406,10 +50406,10 @@
     },
     "ui/visually-hidden": {
       "name": "@washingtonpost/wpds-visually-hidden",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-theme": "1.12.0",
+        "@washingtonpost/wpds-theme": "1.13.0",
         "react": "^16.8.6 || ^17.0.2"
       },
       "devDependencies": {

--- a/ui/accordion/CHANGELOG.md
+++ b/ui/accordion/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-accordion
 
-
-
-
-
 # [1.12.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-accordion
-
-
-
-
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/action-menu/CHANGELOG.md
+++ b/ui/action-menu/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-action-menu
 
-
-
-
-
 # [1.12.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-action-menu
-
-
-
-
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/alert-banner/CHANGELOG.md
+++ b/ui/alert-banner/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-alert-banner
 
-
-
-
-
 # [1.12.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-alert-banner
-
-
-
-
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/app-bar/CHANGELOG.md
+++ b/ui/app-bar/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-app-bar
 
-
-
-
-
 # [1.12.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-app-bar
-
-
-
-
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/avatar/CHANGELOG.md
+++ b/ui/avatar/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-avatar
 
-
-
-
-
 # [1.12.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-avatar
-
-
-
-
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/box/CHANGELOG.md
+++ b/ui/box/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-box
 
-
-
-
-
 # [1.12.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-box
-
-
-
-
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/button/CHANGELOG.md
+++ b/ui/button/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-button
 
-
-
-
-
 # [1.12.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-button
-
-
-
-
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/card/CHANGELOG.md
+++ b/ui/card/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-card
 
-
-
-
-
 # [1.12.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-card
-
-
-
-
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/carousel/CHANGELOG.md
+++ b/ui/carousel/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-carousel
 
-
-
-
-
 # [1.12.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-carousel
-
-
-
-
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/checkbox/CHANGELOG.md
+++ b/ui/checkbox/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-checkbox
 
-
-
-
-
 # [1.12.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-checkbox
-
-
-
-
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/container/CHANGELOG.md
+++ b/ui/container/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-container
 
-
-
-
-
 # [1.12.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-container
-
-
-
-
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/divider/CHANGELOG.md
+++ b/ui/divider/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-divider
 
-
-
-
-
 # [1.12.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-divider
-
-
-
-
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/drawer/CHANGELOG.md
+++ b/ui/drawer/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-drawer
 
-
-
-
-
 # [1.12.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-drawer
-
-
-
-
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/error-message/CHANGELOG.md
+++ b/ui/error-message/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-error-message
 
-
-
-
-
 # [1.12.0](https://github.com/WPMedia/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-error-message
-
-
-
-
 
 ## [1.11.1](https://github.com/WPMedia/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/eslint-plugin/CHANGELOG.md
+++ b/ui/eslint-plugin/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/eslint-plugin-wpds
 
-
-
-
-
 # [1.12.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/eslint-plugin-wpds
-
-
-
-
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/fieldset/CHANGELOG.md
+++ b/ui/fieldset/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-fieldset
 
-
-
-
-
 # [1.12.0](https://github.com/WPMedia/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-fieldset
-
-
-
-
 
 ## [1.11.1](https://github.com/WPMedia/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/helper-text/CHANGELOG.md
+++ b/ui/helper-text/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-helper-text
 
-
-
-
-
 # [1.12.0](https://github.com/WPMedia/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-helper-text
-
-
-
-
 
 ## [1.11.1](https://github.com/WPMedia/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/icon/CHANGELOG.md
+++ b/ui/icon/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-icon
 
-
-
-
-
 # [1.12.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-icon
-
-
-
-
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/input-label/CHANGELOG.md
+++ b/ui/input-label/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-input-label
 
-
-
-
-
 # [1.12.0](https://github.com/WPMedia/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-input-label
-
-
-
-
 
 ## [1.11.1](https://github.com/WPMedia/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/input-password/CHANGELOG.md
+++ b/ui/input-password/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-input-password
 
-
-
-
-
 # [1.12.0](https://github.com/WPMedia/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-input-password
-
-
-
-
 
 ## [1.11.1](https://github.com/WPMedia/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/input-search/CHANGELOG.md
+++ b/ui/input-search/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-input-search
 
-
-
-
-
 # [1.12.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-input-search
-
-
-
-
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/input-shared/CHANGELOG.md
+++ b/ui/input-shared/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-input-shared
 
-
-
-
-
 # [1.12.0](https://github.com/WPMedia/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-input-shared
-
-
-
-
 
 ## [1.11.1](https://github.com/WPMedia/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/input-text/CHANGELOG.md
+++ b/ui/input-text/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-input-text
 
-
-
-
-
 # [1.12.0](https://github.com/WPMedia/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-input-text
-
-
-
-
 
 ## [1.11.1](https://github.com/WPMedia/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/input-textarea/CHANGELOG.md
+++ b/ui/input-textarea/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-input-textarea
 
-
-
-
-
 # [1.12.0](https://github.com/WPMedia/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-input-textarea
-
-
-
-
 
 ## [1.11.1](https://github.com/WPMedia/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/kit/CHANGELOG.md
+++ b/ui/kit/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-ui-kit
 
-
-
-
-
 # [1.12.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-ui-kit
-
-
-
-
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/kitchen-sink/CHANGELOG.md
+++ b/ui/kitchen-sink/CHANGELOG.md
@@ -5,22 +5,13 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [1.13.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.12.0...v1.13.0) (2023-09-18)
 
-
 ### Bug Fixes
 
-* Floating select label SRED-446 ([#501](https://github.com/washingtonpost/wpds-ui-kit/issues/501)) ([c71efa2](https://github.com/washingtonpost/wpds-ui-kit/commit/c71efa29a1c32227251ad3bfa1dbddc6c450d9f4))
-
-
-
-
+- Floating select label SRED-446 ([#501](https://github.com/washingtonpost/wpds-ui-kit/issues/501)) ([c71efa2](https://github.com/washingtonpost/wpds-ui-kit/commit/c71efa29a1c32227251ad3bfa1dbddc6c450d9f4))
 
 # [1.12.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-kitchen-sink
-
-
-
-
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/kitchen-sink/src/KitchenSink.tsx
+++ b/ui/kitchen-sink/src/KitchenSink.tsx
@@ -27,7 +27,7 @@ import {
   Tabs,
   NavigationMenu,
   InputSearch,
-  Select
+  Select,
 } from "@washingtonpost/wpds-ui-kit";
 import { Chart, Settings, Info, Menu } from "@washingtonpost/wpds-assets";
 

--- a/ui/navigation-menu/CHANGELOG.md
+++ b/ui/navigation-menu/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-navigation-menu
 
-
-
-
-
 # [1.12.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-navigation-menu
-
-
-
-
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/pagination-dots/CHANGELOG.md
+++ b/ui/pagination-dots/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-pagination-dots
 
-
-
-
-
 # [1.12.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-pagination-dots
-
-
-
-
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/popover/CHANGELOG.md
+++ b/ui/popover/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-popover
 
-
-
-
-
 # [1.12.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-popover
-
-
-
-
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/radio-group/CHANGELOG.md
+++ b/ui/radio-group/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-radio-group
 
-
-
-
-
 # [1.12.0](https://github.com/WPMedia/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-radio-group
-
-
-
-
 
 ## [1.11.1](https://github.com/WPMedia/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/scrim/CHANGELOG.md
+++ b/ui/scrim/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-scrim
 
-
-
-
-
 # [1.12.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-scrim
-
-
-
-
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/select/CHANGELOG.md
+++ b/ui/select/CHANGELOG.md
@@ -5,22 +5,13 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [1.13.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.12.0...v1.13.0) (2023-09-18)
 
-
 ### Bug Fixes
 
-* Floating select label SRED-446 ([#501](https://github.com/washingtonpost/wpds-ui-kit/issues/501)) ([c71efa2](https://github.com/washingtonpost/wpds-ui-kit/commit/c71efa29a1c32227251ad3bfa1dbddc6c450d9f4))
-
-
-
-
+- Floating select label SRED-446 ([#501](https://github.com/washingtonpost/wpds-ui-kit/issues/501)) ([c71efa2](https://github.com/washingtonpost/wpds-ui-kit/commit/c71efa29a1c32227251ad3bfa1dbddc6c450d9f4))
 
 # [1.12.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-select
-
-
-
-
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/switch/CHANGELOG.md
+++ b/ui/switch/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-switch
 
-
-
-
-
 # [1.12.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-switch
-
-
-
-
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/tabs/CHANGELOG.md
+++ b/ui/tabs/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-tabs
 
-
-
-
-
 # [1.12.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-tabs
-
-
-
-
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/tailwind-theme/CHANGELOG.md
+++ b/ui/tailwind-theme/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-tailwind-theme
 
-
-
-
-
 # [1.12.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-tailwind-theme
-
-
-
-
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/theme/CHANGELOG.md
+++ b/ui/theme/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-theme
 
-
-
-
-
 # [1.12.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-theme
-
-
-
-
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/tooltip/CHANGELOG.md
+++ b/ui/tooltip/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-tooltip
 
-
-
-
-
 # [1.12.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-tooltip
-
-
-
-
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 

--- a/ui/visually-hidden/CHANGELOG.md
+++ b/ui/visually-hidden/CHANGELOG.md
@@ -7,17 +7,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @washingtonpost/wpds-visually-hidden
 
-
-
-
-
 # [1.12.0](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.1...v1.12.0) (2023-09-13)
 
 **Note:** Version bump only for package @washingtonpost/wpds-visually-hidden
-
-
-
-
 
 ## [1.11.1](https://github.com/washingtonpost/wpds-ui-kit/compare/v1.11.0...v1.11.1) (2023-08-23)
 


### PR DESCRIPTION
## What I did

This PR applies missing formatting to files from a failed full deployment
