### PR TITLE
fix: adding key to cloned carousel items

### DIFF
--- a/ui/carousel/src/CarouselContent.tsx
+++ b/ui/carousel/src/CarouselContent.tsx
@@ -252,6 +252,7 @@ export const CarouselContent = React.forwardRef<
                   "aria-label": `${index + 1} of ${totalItems}`,
                   id: child.props.id || `${idRef.current}-item${index}`,
                   ref: (ref: HTMLLIElement) => (childRefs.current[index] = ref),
+                  key: child.props.id || `${idRef.current}-item${index}`
                 }
               );
             }


### PR DESCRIPTION
i had warnings in my console to add a key so I added one here, i don't think there are any issues with keys and clone elements. 