### PR TITLE
fix: anchor link for getting started

### DIFF
--- a/build.washingtonpost.com/docs/foundations/wam.mdx
+++ b/build.washingtonpost.com/docs/foundations/wam.mdx
@@ -8,7 +8,7 @@ description: WPDS Asset-Manager (also known as WAM) manages all assets as raw SV
 
 ## Table of contents
 
-- [Getting started](foundations/wam#Getting%20started)
+- [Getting started](/foundations/wam#Getting%20started)
 - [Design principles](/foundations/wam#Design%20principles)
 - [Icon design principles](/foundations/wam#Icon%20design%20principles)
 - [Icon requests](/foundations/wam#Request)


### PR DESCRIPTION
## What I did

<!--
  Explain the **motivation** for making this change. What existing problem does the pull request solve? Please be as detailed as possible.
-->

The Getting started link was not working on the WAM doc because it was missing the `/` so I added it
