### PR TITLE
feat: add link to storybook in component doc page

### DIFF
--- a/build.washingtonpost.com/components/ComponentPage/ComponentDetails.jsx
+++ b/build.washingtonpost.com/components/ComponentPage/ComponentDetails.jsx
@@ -106,6 +106,33 @@ export const ComponentDetails = ({
           color: "inherit",
         }}
       >
+        Storybook: &nbsp;
+        <CustomLink
+          css={{
+            color: theme.colors.accessible,
+            textDecoration: "underline",
+            fontWeight: theme.fontWeights.regular,
+            "&:focus": {
+              outlineColor: "$signal",
+              outlineStyle: "solid",
+              outlineOffset: "2px",
+              outlineWidth: "2px",
+            },
+          }}
+          href={`https://wpds-ui-kit-storybook.preview.now.washingtonpost.com/?path=/story/${current}`}
+          title={"View on Storybook"}
+        >
+          View on Storybook
+        </CustomLink>
+      </Box>
+      <Box
+        css={{
+          display: "flex",
+          fontWeight: "$bold",
+          textDecoration: "none",
+          color: "inherit",
+        }}
+      >
         Source: &nbsp;
         <CustomLink
           css={{


### PR DESCRIPTION
## What I did

![CleanShot 2023-11-13 at 23 34 52@2x](https://github.com/washingtonpost/wpds-ui-kit/assets/347490/9943ade1-77bb-41e6-9945-4f32ef684679)


https://wpds-ui-kit-storybook.preview.now.washingtonpost.com/?path=/story/action-menu 

<!--
  Explain the **motivation** for making this change. What existing problem does the pull request solve? Please be as detailed as possible.
-->
