### PR TITLE
fix: prevent Input text from being highlighted when Input Text Area is the active page in guide

### DIFF
--- a/build.washingtonpost.com/components/Layout/Components/Sidebar.js
+++ b/build.washingtonpost.com/components/Layout/Components/Sidebar.js
@@ -259,9 +259,7 @@ export default function Sidebar({ navigation, setMobileMenu }) {
                                 onClick={() => setMobileMenu(false)}
                                 key={index}
                                 isCurrent={
-                                  router.asPath.includes(item.slug)
-                                    ? "active"
-                                    : ""
+                                  router.asPath === item.slug ? "active" : ""
                                 }
                                 disabled={item.data.status === "Coming soon"}
                               >


### PR DESCRIPTION
## What I did

updated the comparison for active nav item

SRED-629