### PR TITLE
fix: tooltip portal [R18-10]

### DIFF
--- a/docs/architecture/003-css-framework.md
+++ b/docs/architecture/003-css-framework.md
@@ -6,11 +6,11 @@ The current CSS framework, [Stitches](https://stitches.dev/), is no longer maint
 
 ## Decision Drivers
 
-* Similarity of new framework API to Stitches, both for consumer onboarding and automated conversion
+- Similarity of new framework API to Stitches, both for consumer onboarding and automated conversion
 
-* Ability to work with our current tooling. Storybook for development, tsup for compilation, and Next.js for production applications
+- Ability to work with our current tooling. Storybook for development, tsup for compilation, and Next.js for production applications
 
-* Ability to work with other styling options in current use including Tailwind. 
+- Ability to work with other styling options in current use including Tailwind.
 
 ## Decision
 
@@ -19,18 +19,21 @@ We propose adopting Panda CSS, a compile-time CSS-in-JS framework, as the new CS
 We will continue to maintain a Tailwind theme that can be used in conjunction with our components for teams that prefer a utility class based approach to styling.
 
 ## Considered Options
-* [Vanilla Extract](https://vanilla-extract.style/): Considered for its approach to type-safe styles and compile-time generation of stylesheets.
-  * Uses external *.css.ts breaking our current colocated styles
-  * Does not have a compatible plug-in for Next 13.x or 14.x
-  * Documented integration with Storybook is broken
-  * Approach to variants is significantly different from Stitches adding to level of effort
 
-* [StyleX](https://stylexjs.com/): Examined for its runtime performance, support for dynamic theming, and expected long-term support from Meta.
-  * No plugin is available for esbuild or tsup forcing a significant change to our compilation process
-  * Override styles must use `stylex.create` , both className and style are actively discouraged or prevented. Generated classes are high strength and difficult to override
-  * Approach to themes and variants is significantly different from Stitches adding to the level of effort
+- [Vanilla Extract](https://vanilla-extract.style/): Considered for its approach to type-safe styles and compile-time generation of stylesheets.
+
+  - Uses external \*.css.ts breaking our current colocated styles
+  - Does not have a compatible plug-in for Next 13.x or 14.x
+  - Documented integration with Storybook is broken
+  - Approach to variants is significantly different from Stitches adding to level of effort
+
+- [StyleX](https://stylexjs.com/): Examined for its runtime performance, support for dynamic theming, and expected long-term support from Meta.
+  - No plugin is available for esbuild or tsup forcing a significant change to our compilation process
+  - Override styles must use `stylex.create` , both className and style are actively discouraged or prevented. Generated classes are high strength and difficult to override
+  - Approach to themes and variants is significantly different from Stitches adding to the level of effort
 
 ## Resources
+
 [Panda CSS Spike](https://arcpublishing.atlassian.net/browse/SRED-318)
 [Vanilla Extract CSS Spike](https://arcpublishing.atlassian.net/browse/SRED-317)
 [StyleX CSS Spike](https://arcpublishing.atlassian.net/browse/SRED-643)

--- a/ui/tooltip/src/TooltipContent.tsx
+++ b/ui/tooltip/src/TooltipContent.tsx
@@ -84,6 +84,7 @@ export interface TooltipContentInterface extends ContentCombinedProps {
   /** how far away from the center do you want the tooltip to be? */
   /** @default 0 */
   offsetAlign?: number | string | WPDSThemeSpaceObject;
+  container?: HTMLElement;
 }
 
 /**
@@ -104,12 +105,13 @@ export const TooltipContent = React.forwardRef<
       side = "top",
       align = "center",
       offsetAlign = 0,
+      container,
       ...props
     }: TooltipContentInterface,
     ref
   ) =>
     disabled ? null : (
-      <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Portal container={container}>
         <StyledContentWrapper
           {...props}
           sideOffset={getPixelsFromRem(offsetSide)}

--- a/ui/tooltip/src/play.stories.tsx
+++ b/ui/tooltip/src/play.stories.tsx
@@ -104,6 +104,56 @@ const TemplateBottom: ComponentStory<any> = (args) => (
 );
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
+const TemplatePortal: ComponentStory<any> = (args) => {
+  const [container, setContainer] = React.useState(null);
+  const handleRef = (e) => {
+    setContainer(e);
+  };
+  return (
+    <>
+      <div id={"container-id"} ref={handleRef} />
+      <Tooltip.Provider {...args}>
+        <Tooltip.Root open={true}>
+          <Tooltip.Trigger>
+            <span>This is a tooltip trigger</span>
+          </Tooltip.Trigger>
+          <Tooltip.Portal container={container}>
+            <Tooltip.Content side="bottom" {...args}>
+              This should render as a child of #container-id
+            </Tooltip.Content>
+          </Tooltip.Portal>
+        </Tooltip.Root>
+      </Tooltip.Provider>
+    </>
+  );
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const TemplateContentContainter: ComponentStory<any> = (args) => {
+  const [container, setContainer] = React.useState(null);
+  const handleRef = (e) => {
+    setContainer(e);
+  };
+  return (
+    <>
+      <div id={"container-id"} ref={handleRef} />
+      <Tooltip.Provider {...args}>
+        <Tooltip.Root open={true}>
+          <Tooltip.Trigger>
+            <span>This is a tooltip trigger</span>
+          </Tooltip.Trigger>
+          <Tooltip.Portal>
+            <Tooltip.Content container={container} side="bottom" {...args}>
+              This should render as a child of #container-id
+            </Tooltip.Content>
+          </Tooltip.Portal>
+        </Tooltip.Root>
+      </Tooltip.Provider>
+    </>
+  );
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const TemplateDisabled: ComponentStory<any> = (args) => (
   <Tooltip.Provider {...args}>
     <Tooltip.Root defaultOpen={true}>
@@ -125,6 +175,8 @@ export const PlacedOnRight = TemplateRight.bind({});
 export const PlacedOnLeft = TemplateLeft.bind({});
 export const PlacedOnBottom = TemplateBottom.bind({});
 export const Disabled = TemplateDisabled.bind({});
+export const Portal = TemplatePortal.bind({});
+export const ContentContainer = TemplateContentContainter.bind({});
 
 Default.args = {
   density: "compact",


### PR DESCRIPTION
## What I did

I am trying to switch to the `ui-kit` version of Tooltip in the video player exported from [media-components](https://github.com/WPMedia/media-components). Currently we use the deprecated site-components Tooltip for a share menu inside the video player. 

Unfortunately, the upgrade has introduced a bug where the Tooltip will not render in fullscreen. This is caused because, with the `ui-kit` version of Tooltip, the TooltipContent is not rendered as a child of the full screen component, but rather at the top level of `document.body`.

My hope was to use the TooltipPortal to fix this problem, by portaling the component to the supplied `container` prop. As described in the [radix docs](https://www.radix-ui.com/primitives/docs/components/tooltip) - the container prop is used to 'Specify a container element to portal the content into.' At the moment, the ui-kit version of portal is not working that way. Checkout [this new story](https://wpds-ui-kit-storybook-git-r18-10-tooltip-portal.preview.now.washingtonpost.com/?path=%2Fstory%2Ftooltip--portal&vercelToolbarCode=_KFskxav-cHHf0Z) to see the issue. If you pull up the dom, you'll see that the Tooltip content is rendered at the top level of `document.body` rather than as a child of the supplied container element. 

I believe that this issue arrises from the ui-kit TooltipContent element rendering its own Tooltip Portal as a child. I believe having the two nested portals is causing the container prop not to work. So, for a solution, Ive instead surfaced a container prop on the TooltipContent, which Im in turn passing through to the Portal already rendered in TooltipContent. To see how this is functioning, checkout [this new story](https://wpds-ui-kit-storybook-git-r18-10-tooltip-portal.preview.now.washingtonpost.com/?path=%2Fstory%2Ftooltip--content-container&vercelToolbarCode=_KFskxav-cHHf0Z). If you pull up the dom, you can see the Content is now rendering as a child of the supplied container prop. 