### PR TITLE
fix: make input helper and error text block level elements for consistent formatting

### DIFF
--- a/ui/error-message/src/ErrorMessage.tsx
+++ b/ui/error-message/src/ErrorMessage.tsx
@@ -9,9 +9,10 @@ const ErrorMessageCSS = css({
   fontSize: theme.fontSizes["075"],
   fontWeight: theme.fontWeights.light,
   lineHeight: 1.33,
+  marginBlock: 0,
 });
 
-interface ErrorMessageProps extends React.ComponentPropsWithRef<"span"> {
+interface ErrorMessageProps extends React.ComponentPropsWithRef<"p"> {
   /** Allows any React node as children to allow for formatted text and links */
   children?: React.ReactNode;
   /** Id is used to associate the error message with the `aria-errormessage` attribute of another element */
@@ -19,13 +20,13 @@ interface ErrorMessageProps extends React.ComponentPropsWithRef<"span"> {
 }
 
 export const ErrorMessage = React.forwardRef<
-  HTMLSpanElement,
+  HTMLParagraphElement,
   ErrorMessageProps
 >(({ children, ...rest }, ref) => {
   return (
-    <span className={ErrorMessageCSS()} ref={ref} {...rest}>
+    <p className={ErrorMessageCSS()} ref={ref} {...rest}>
       {children}
-    </span>
+    </p>
   );
 });
 

--- a/ui/helper-text/src/HelperText.tsx
+++ b/ui/helper-text/src/HelperText.tsx
@@ -9,24 +9,26 @@ const HelperTextCSS = css({
   fontSize: theme.fontSizes["075"],
   fontWeight: theme.fontWeights.light,
   lineHeight: 1.33,
+  marginBlock: 0,
 });
 
-interface HelperTextProps extends React.ComponentPropsWithRef<"span"> {
+interface HelperTextProps extends React.ComponentPropsWithRef<"p"> {
   /** Allows any React node as children to allow for formatted text and links */
   children?: React.ReactNode;
   /** Id is used to associate the text with the `aria-describedby` attribute of another element */
   id?: string;
 }
 
-export const HelperText = React.forwardRef<HTMLSpanElement, HelperTextProps>(
-  ({ children, ...rest }, ref) => {
-    return (
-      <span className={HelperTextCSS()} ref={ref} {...rest}>
-        {children}
-      </span>
-    );
-  }
-);
+export const HelperText = React.forwardRef<
+  HTMLParagraphElement,
+  HelperTextProps
+>(({ children, ...rest }, ref) => {
+  return (
+    <p className={HelperTextCSS()} ref={ref} {...rest}>
+      {children}
+    </p>
+  );
+});
 
 HelperText.displayName = NAME;
 


### PR DESCRIPTION
## What I did

This PR changes the HelperText and ErrorMessage elements to be block-level elements so their line height is always consistent