### PR TITLE
fix: updated React types package to prevent type errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "@testing-library/user-event": "^13.5.0",
         "@types/jest": "^28.1.8",
         "@types/node": "^17.0.21",
-        "@types/react": "^17.0.39",
+        "@types/react": "^17.0.79",
         "@types/react-dom": "^17.0.11",
         "@typescript-eslint/eslint-plugin": "^5.12.0",
         "@typescript-eslint/parser": "^5.12.0",
@@ -18611,8 +18611,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "17.0.39",
-      "license": "MIT",
+      "version": "17.0.79",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.79.tgz",
+      "integrity": "sha512-gavKA8AwJAML9zWHuiQRASjrrPJHbT/zrUDHiUGUf+l5a3pkEd6atvjjq+8y2vfRHBJLQJjFpxSa9I8qe9zHAw==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -50726,6 +50727,7 @@
         "typescript": "4.5.5"
       },
       "peerDependencies": {
+        "@types/react": "^17.0.79",
         "@washingtonpost/eslint-plugin-wpds": "*",
         "@washingtonpost/wpds-accordion": "*",
         "@washingtonpost/wpds-action-menu": "*",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@testing-library/user-event": "^13.5.0",
     "@types/jest": "^28.1.8",
     "@types/node": "^17.0.21",
-    "@types/react": "^17.0.39",
+    "@types/react": "^17.0.79",
     "@types/react-dom": "^17.0.11",
     "@typescript-eslint/eslint-plugin": "^5.12.0",
     "@typescript-eslint/parser": "^5.12.0",

--- a/ui/kit/package.json
+++ b/ui/kit/package.json
@@ -74,6 +74,7 @@
     "typescript": "4.5.5"
   },
   "peerDependencies": {
+    "@types/react": "^17.0.79",
     "@washingtonpost/eslint-plugin-wpds": "*",
     "@washingtonpost/wpds-accordion": "*",
     "@washingtonpost/wpds-action-menu": "*",


### PR DESCRIPTION
## What I did

This PR updates the `@types/react` package to get rid of erroneous type errors caused by the removal of certain props from the package
