### PR TITLE
feat: increase the specificity of the wpds-dark selector to ensure it overrides light variables

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,4 +8,4 @@ node_modules
 out
 jest-coverage
 plop-templates
-/ui/theme/src/tokens.ts
+ui/theme/src/tokens.ts

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "extends": "./tsconfig.base.json",
+  "exclude": ["./ui/theme/src/tokens.ts"],
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {

--- a/ui/theme/src/stitches.config.ts
+++ b/ui/theme/src/stitches.config.ts
@@ -113,13 +113,20 @@ export const {
 } = WPDS;
 export const utils = config.utils;
 
-export const darkTheme = createTheme(`${prefix}-dark`, {
+const _darkTheme = createTheme(`${prefix}-dark.${prefix}-dark`, {
   colors: {
     ...tokens.dark,
     ...tokens.staticColors,
     ...tokens.darkTheme,
   },
 });
+
+export const darkTheme = {
+  className: `${prefix}-dark`,
+  selector: _darkTheme.selector,
+  colors: _darkTheme.colors,
+  toString: () => `${prefix}-dark`,
+};
 
 export const globalStyles = globalCss({
   ":root": {


### PR DESCRIPTION
## What I did
This PR increases the specificity of the wpds-dark selector to a strength of 020 by using a multiple class selector that is a duplicate of itself, allowing the class attribute to remain the same.

This ensures that the dark theme custom properties override light theme, even when light the theme properties are rewritten into the dom by dynamically loaded components.   

```
.wpds-dark.wpds-dark {
  --wpds-colors-gray700: rgba(...)
  ...
}
...
<html class="wpds-dark">
```
