### PR TITLE
fix: add tokens specifier to exports

### DIFF
--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -70,6 +70,7 @@
     "./src/theme/wpds.tokens.json": "./src/theme/wpds.tokens.json",
     "./src/theme/hexcodes.tokens.json": "./src/theme/hexcodes.tokens.json",
     "./src/input-search/cities": "./src/input-search/cities",
+    "./src/theme/tokens": "./src/theme/tokens",
     ".": {
       "source": "./src/index.ts",
       "import": {


### PR DESCRIPTION
## What I did

I noticed an issue with updating a reference in furniture EHF to use kit tokens file. 

> [commonjs--resolver] Missing "./src/theme/tokens" specifier in "@washingtonpost/wpds-ui-kit" package

<!--
  Explain the **motivation** for making this change. What existing problem does the pull request solve? Please be as detailed as possible.
-->
