### PR TITLE
fix: remove global styles from wpds-tokens

### DIFF
--- a/ui/tokens/scripts/build.mjs
+++ b/ui/tokens/scripts/build.mjs
@@ -10,6 +10,7 @@ const css = renderToString(
   })
 );
 
+// Needed in order for the react render (with stitches) to generate the dark color tokens
 // eslint-disable-next-line testing-library/render-result-naming-convention
 const div = renderToString(
   React.createElement("div", {

--- a/ui/tokens/scripts/build.mjs
+++ b/ui/tokens/scripts/build.mjs
@@ -1,10 +1,6 @@
 import React from "react";
 import { renderToString } from "react-dom/server.js";
-import {
-  getCssText,
-  darkModeGlobalStyles,
-  darkTheme,
-} from "@washingtonpost/wpds-theme";
+import { getCssText, darkTheme } from "@washingtonpost/wpds-theme";
 import fs from "fs";
 
 // eslint-disable-next-line testing-library/render-result-naming-convention

--- a/ui/tokens/scripts/build.mjs
+++ b/ui/tokens/scripts/build.mjs
@@ -1,24 +1,25 @@
 import React from "react";
 import { renderToString } from "react-dom/server.js";
-import { getCssText, globalStyles, darkModeGlobalStyles, darkTheme } from "@washingtonpost/wpds-theme";
+import {
+  getCssText,
+  darkModeGlobalStyles,
+  darkTheme,
+} from "@washingtonpost/wpds-theme";
 import fs from "fs";
 
 // eslint-disable-next-line testing-library/render-result-naming-convention
 const css = renderToString(
-    React.createElement("style", {
-        dangerouslySetInnerHTML: { __html: getCssText() }
-    })
+  React.createElement("style", {
+    dangerouslySetInnerHTML: { __html: getCssText() },
+  })
 );
 
 // eslint-disable-next-line testing-library/render-result-naming-convention
 const div = renderToString(
-    React.createElement("div", {
-        className: darkTheme
-    })
+  React.createElement("div", {
+    className: darkTheme,
+  })
 );
-
-globalStyles();
-darkModeGlobalStyles();
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const template = `


### PR DESCRIPTION
## What I did

This removes the global styles from wpds-tokens. We want that package to contain only tokens, or else a user cannot import it without getting the global styles added to their application as well (Spaces ran into this issue).

This thread has more context: https://washpost.slack.com/archives/C01FWHF12BG/p1711660089255659
Ticket: https://arcpublishing.atlassian.net/browse/CRX-1227
