### PR TITLE
chore: the builds were breaking with these options added

### DIFF
--- a/build.washingtonpost.com/next.config.js
+++ b/build.washingtonpost.com/next.config.js
@@ -102,14 +102,6 @@ module.exports = withBundleAnalyzer({
       },
     ];
   },
-  experimental: {
-    bundlePagesExternals: true,
-    optimizePackageImports: [
-      "@washingtonpost/wpds-ui-kit",
-      "@washingtonpost/wpds-assets",
-      "@washingtonpost/media-components",
-    ],
-  },
   env: {
     APP_ENV: "production",
   },


### PR DESCRIPTION
my local builds weren't working, showing errors like this.


```
@washingtonpost/wpds-docs:build: ../packages/kit/dist/esm/index.js
@washingtonpost/wpds-docs:build: Module not found: Can't resolve './chunk-RWSJFR6A.js'
@washingtonpost/wpds-docs:build: 
@washingtonpost/wpds-docs:build: https://nextjs.org/docs/messages/module-not-found
@washingtonpost/wpds-docs:build: 
@washingtonpost/wpds-docs:build: Import trace for requested module:
@washingtonpost/wpds-docs:build: ./components/Markdown/Examples/HexRGBAColorSamples.jsx
@washingtonpost/wpds-docs:build: ./components/Markdown/Styling.js
@washingtonpost/wpds-docs:build: ./pages/playroom.js
```