### PR TITLE
fix: update dark mode color Red100 to new value [STRY-567]

### DIFF
--- a/packages/kit/src/theme/wpds.tokens.json
+++ b/packages/kit/src/theme/wpds.tokens.json
@@ -955,8 +955,8 @@
       },
       "red100": {
         "type": "color",
-        "hex": "#f02e41",
-        "value": "rgba(240, 46, 65, 1)"
+        "hex": "#ff3636",
+        "value": "rgba(255, 54, 54, 1)"
       },
       "red80": {
         "type": "color",


### PR DESCRIPTION
## What I did

Change dark mode color value for Hex and RGB

Current Hex: #F02E41
Change Hex to: #FF3636

<!--
  Explain the **motivation** for making this change. What existing problem does the pull request solve? Please be as detailed as possible.
-->
