### PR TITLE
fix: prevent frozen InputSearch after text editing

### DIFF
--- a/packages/kit/src/input-search/InputSearchInput.tsx
+++ b/packages/kit/src/input-search/InputSearchInput.tsx
@@ -44,7 +44,6 @@ export const InputSearchInput = React.forwardRef<
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
       if (rest.onChange) rest.onChange(event);
       if (inputProps.onChange) inputProps.onChange(event);
-      console.log("InputSearchInput handleChange", event.target.value);
     };
 
     const [tempText, setTempText] = React.useState<string>();

--- a/packages/kit/src/input-search/InputSearchInput.tsx
+++ b/packages/kit/src/input-search/InputSearchInput.tsx
@@ -44,6 +44,7 @@ export const InputSearchInput = React.forwardRef<
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
       if (rest.onChange) rest.onChange(event);
       if (inputProps.onChange) inputProps.onChange(event);
+      console.log("InputSearchInput handleChange", event.target.value);
     };
 
     const [tempText, setTempText] = React.useState<string>();
@@ -65,7 +66,7 @@ export const InputSearchInput = React.forwardRef<
     if (value) {
       inputProps.value = value;
     }
-    if (autocomplete && tempText !== undefined) {
+    if (autocomplete && withKeyboard.current) {
       inputProps.value = tempText;
     }
 

--- a/packages/kit/src/input-search/InputSearchRoot.tsx
+++ b/packages/kit/src/input-search/InputSearchRoot.tsx
@@ -100,11 +100,17 @@ export const InputSearchRoot = ({
     state
   );
 
+  const prevSelectedKey = React.useRef(state.selectedKey);
   React.useEffect(() => {
-    if (state.selectedItem && onSelect) {
+    if (
+      state.selectedItem &&
+      onSelect &&
+      prevSelectedKey.current !== state.selectedKey
+    ) {
       onSelect(
         state.selectedItem.textValue || (state.selectedItem.rendered as string)
       );
+      prevSelectedKey.current = state.selectedKey;
     }
   }, [state.selectedItem, onSelect]);
 

--- a/packages/kit/src/input-search/play.stories.tsx
+++ b/packages/kit/src/input-search/play.stories.tsx
@@ -222,9 +222,6 @@ export const Scroll = {
 
 const ControlledTemplate: StoryFn<typeof InputSearch.Root> = (args) => {
   const [term, setTerm] = useState("");
-  useEffect(() => {
-    console.log("term updated....", term);
-  }, [term]);
   return (
     <Box css={{ width: "275px" }}>
       <InputSearch.Root
@@ -232,7 +229,6 @@ const ControlledTemplate: StoryFn<typeof InputSearch.Root> = (args) => {
         aria-label="Example-Search"
         openOnFocus
         onSelect={(value) => {
-          console.log("story onSelect", value);
           setTerm(value);
         }}
       >
@@ -241,7 +237,6 @@ const ControlledTemplate: StoryFn<typeof InputSearch.Root> = (args) => {
           id="fruit"
           value={term}
           onChange={(event) => {
-            console.log("story onChange", event.target.value);
             setTerm(event.target.value);
           }}
         />

--- a/packages/kit/src/input-search/play.stories.tsx
+++ b/packages/kit/src/input-search/play.stories.tsx
@@ -28,8 +28,8 @@ const useCityMatch = (term: string) => {
       term.trim() === ""
         ? null
         : matchSorter(cities, term, {
-          keys: [(item) => `${item.city}, ${item.state}`],
-        }),
+            keys: [(item) => `${item.city}, ${item.state}`],
+          }),
     [term]
   );
 };
@@ -222,6 +222,9 @@ export const Scroll = {
 
 const ControlledTemplate: StoryFn<typeof InputSearch.Root> = (args) => {
   const [term, setTerm] = useState("");
+  useEffect(() => {
+    console.log("term updated....", term);
+  }, [term]);
   return (
     <Box css={{ width: "275px" }}>
       <InputSearch.Root
@@ -229,6 +232,7 @@ const ControlledTemplate: StoryFn<typeof InputSearch.Root> = (args) => {
         aria-label="Example-Search"
         openOnFocus
         onSelect={(value) => {
+          console.log("story onSelect", value);
           setTerm(value);
         }}
       >
@@ -237,6 +241,7 @@ const ControlledTemplate: StoryFn<typeof InputSearch.Root> = (args) => {
           id="fruit"
           value={term}
           onChange={(event) => {
+            console.log("story onChange", event.target.value);
             setTerm(event.target.value);
           }}
         />
@@ -290,5 +295,25 @@ export const Interactions = {
     });
     await userEvent.keyboard("[ArrowDown]");
     await expect(input).toHaveDisplayValue("Apple");
+  },
+};
+
+export const ControlledKeyboardInteractions = {
+  render: ControlledTemplate,
+
+  play: async () => {
+    const input = await screen.findByLabelText("Search");
+    await userEvent.type(input, "app", {
+      delay: 100,
+    });
+    await userEvent.keyboard("[ArrowDown]");
+    await userEvent.keyboard("[ArrowDown]");
+    await userEvent.keyboard("[ArrowDown]");
+    await expect(input).toHaveDisplayValue("Orange");
+    await userEvent.keyboard("[Backspace]");
+    await expect(input).toHaveDisplayValue("Orang");
+    const clearButton = await screen.findByText("Clear");
+    await userEvent.click(clearButton);
+    await expect(input).toHaveDisplayValue("");
   },
 };


### PR DESCRIPTION
## What I did

This PR slightly refactors input search to better respond to keyboard interaction and edits to selected text, as well as adding an interaction test story to validate

Steps to test

1. Start searching
2. Key down to one of the autocomplete suggestions
3. Try making a change to the autocomplete result in the search bar by backspacing or typing more letters
4. Changes **are** made as expected
5. Clear the search bar by clicking the x icon, it clears as expected

STRY-679
