### PR TITLE
fix: update component github links on build site

### DIFF
--- a/build.washingtonpost.com/components/ComponentPage/ComponentDetails.jsx
+++ b/build.washingtonpost.com/components/ComponentPage/ComponentDetails.jsx
@@ -146,7 +146,7 @@ export const ComponentDetails = ({
               outlineWidth: "2px",
             },
           }}
-          href={`https://github.com/washingtonpost/wpds-ui-kit/tree/main/ui/${current}`}
+          href={`https://github.com/washingtonpost/wpds-ui-kit/tree/main/packages/kit/src/${current}`}
           title={"View on Github"}
         >
           View on Github


### PR DESCRIPTION
## What I did

### Problem

The GitHub link to each component's source code goes to the wrong directory.

For example, the source code for the [Box]() component goes to the [old `ui` directory](https://github.com/washingtonpost/wpds-ui-kit/tree/main/ui/box) when it should go to the [new `packages/kit/src`directory](https://github.com/washingtonpost/wpds-ui-kit/tree/main/packages/kit/src/box)

### Solution

Point all component GitHub links to the correct directory within the repository.

