### PR TITLE
feat: update wpds-assets

### DIFF
--- a/build.washingtonpost.com/package.json
+++ b/build.washingtonpost.com/package.json
@@ -26,7 +26,7 @@
     "@washingtonpost/site-favicons": "0.3.4-alpha.1",
     "@washingtonpost/site-footer": "0.25.3-alpha.1",
     "@washingtonpost/tachyons-css": "^1.8.0",
-    "@washingtonpost/wpds-assets": "^2.8.0",
+    "@washingtonpost/wpds-assets": "^2.9.0",
     "@washingtonpost/wpds-kitchen-sink": "2.9.0",
     "@washingtonpost/wpds-tailwind-theme": "2.9.0",
     "@washingtonpost/wpds-tokens": "2.9.0",
@@ -79,6 +79,6 @@
   "overrides": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "@washingtonpost/wpds-assets": "^2.8.0"
+    "@washingtonpost/wpds-assets": "^2.9.0"
   }
 }

--- a/build.washingtonpost.com/package.json
+++ b/build.washingtonpost.com/package.json
@@ -26,7 +26,7 @@
     "@washingtonpost/site-favicons": "0.3.4-alpha.1",
     "@washingtonpost/site-footer": "0.25.3-alpha.1",
     "@washingtonpost/tachyons-css": "^1.8.0",
-    "@washingtonpost/wpds-assets": "^2.7.0",
+    "@washingtonpost/wpds-assets": "^2.8.0",
     "@washingtonpost/wpds-kitchen-sink": "2.9.0",
     "@washingtonpost/wpds-tailwind-theme": "2.9.0",
     "@washingtonpost/wpds-tokens": "2.9.0",
@@ -79,6 +79,6 @@
   "overrides": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "@washingtonpost/wpds-assets": "^2.7.0"
+    "@washingtonpost/wpds-assets": "^2.8.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       ],
       "dependencies": {
         "@babel/standalone": "^7.17.11",
-        "@washingtonpost/wpds-assets": "^2.7.0",
+        "@washingtonpost/wpds-assets": "^2.8.0",
         "typescript": "4.5.5"
       },
       "devDependencies": {
@@ -327,7 +327,7 @@
         "@washingtonpost/site-favicons": "0.3.4-alpha.1",
         "@washingtonpost/site-footer": "0.25.3-alpha.1",
         "@washingtonpost/tachyons-css": "^1.8.0",
-        "@washingtonpost/wpds-assets": "^2.7.0",
+        "@washingtonpost/wpds-assets": "^2.8.0",
         "@washingtonpost/wpds-kitchen-sink": "2.9.0",
         "@washingtonpost/wpds-tailwind-theme": "2.9.0",
         "@washingtonpost/wpds-tokens": "2.9.0",
@@ -13662,9 +13662,9 @@
       "integrity": "sha512-Nq/KTKohoO35MEHe3HuQRpFR3KpC6qP7XyDw7HT4mV3AhkD3p99Zz/XjALXEk0/Cb/9WWpaZgeR7naWbsLOyEQ=="
     },
     "node_modules/@washingtonpost/wpds-assets": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-assets/-/wpds-assets-2.7.0.tgz",
-      "integrity": "sha512-2amLvqNiIC9dlY9JoXYtb03ui5Xz+0mxdHYbfT0REKvuDpF6Q8b4A1ZYsxKYN7RUzVe2jLQutuEH8N0Uo5T3BQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-assets/-/wpds-assets-2.8.0.tgz",
+      "integrity": "sha512-R7bRJFLG+TYwGTlKIBdUPrlyk/FLx7pPpW8fB5RE/U8JD+dp6lqfvs9yhFBaG4gV/3HIZNe0m86vAxO7VYee/A==",
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -38965,7 +38965,7 @@
         "jest": "^28.1.0"
       },
       "peerDependencies": {
-        "@washingtonpost/wpds-ui-kit": "2.0.0-alpha.10"
+        "@washingtonpost/wpds-ui-kit": "2.9.0"
       }
     },
     "packages/eslint-plugin/node_modules/@jest/console": {
@@ -39962,7 +39962,7 @@
         "@react-types/combobox": "^3.11.1",
         "@react-types/shared": "^3.23.1",
         "@stitches/react": "1.3.1-1",
-        "@washingtonpost/wpds-assets": "^2.7.0",
+        "@washingtonpost/wpds-assets": "^2.8.0",
         "match-sorter": "6.3.1",
         "nanoid": "^3.3.4",
         "popper-max-size-modifier": "^0.2.0",
@@ -40008,7 +40008,7 @@
       "version": "2.9.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-assets": "^2.7.0",
+        "@washingtonpost/wpds-assets": "^2.8.0",
         "@washingtonpost/wpds-ui-kit": "2.9.0",
         "nanoid": "^3.3.4"
       },
@@ -40017,8 +40017,8 @@
         "typescript": "4.5.5"
       },
       "peerDependencies": {
-        "@washingtonpost/wpds-assets": "^2.7.0",
-        "@washingtonpost/wpds-ui-kit": "2.1.0",
+        "@washingtonpost/wpds-assets": "^2.8.0",
+        "@washingtonpost/wpds-ui-kit": "2.9.0",
         "react": "^18.2.0"
       }
     },
@@ -40036,7 +40036,7 @@
         "vite": "^4.3.9"
       },
       "peerDependencies": {
-        "@washingtonpost/wpds-ui-kit": "2.0.0-alpha.10"
+        "@washingtonpost/wpds-ui-kit": "2.9.0"
       }
     },
     "packages/tokens": {
@@ -40044,7 +40044,7 @@
       "version": "2.9.0",
       "license": "MIT",
       "devDependencies": {
-        "@washingtonpost/wpds-assets": "^2.7.0",
+        "@washingtonpost/wpds-assets": "^2.8.0",
         "@washingtonpost/wpds-ui-kit": "2.9.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       ],
       "dependencies": {
         "@babel/standalone": "^7.17.11",
-        "@washingtonpost/wpds-assets": "^2.8.0",
+        "@washingtonpost/wpds-assets": "^2.9.0",
         "typescript": "4.5.5"
       },
       "devDependencies": {
@@ -327,7 +327,7 @@
         "@washingtonpost/site-favicons": "0.3.4-alpha.1",
         "@washingtonpost/site-footer": "0.25.3-alpha.1",
         "@washingtonpost/tachyons-css": "^1.8.0",
-        "@washingtonpost/wpds-assets": "^2.8.0",
+        "@washingtonpost/wpds-assets": "^2.9.0",
         "@washingtonpost/wpds-kitchen-sink": "2.9.0",
         "@washingtonpost/wpds-tailwind-theme": "2.9.0",
         "@washingtonpost/wpds-tokens": "2.9.0",
@@ -13662,9 +13662,9 @@
       "integrity": "sha512-Nq/KTKohoO35MEHe3HuQRpFR3KpC6qP7XyDw7HT4mV3AhkD3p99Zz/XjALXEk0/Cb/9WWpaZgeR7naWbsLOyEQ=="
     },
     "node_modules/@washingtonpost/wpds-assets": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-assets/-/wpds-assets-2.8.0.tgz",
-      "integrity": "sha512-R7bRJFLG+TYwGTlKIBdUPrlyk/FLx7pPpW8fB5RE/U8JD+dp6lqfvs9yhFBaG4gV/3HIZNe0m86vAxO7VYee/A==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/wpds-assets/-/wpds-assets-2.9.0.tgz",
+      "integrity": "sha512-PD0gIrnAEpRhQiJ8zv0Voi91CGY8KpqTmX1QiFIHGiyJV0Wm5hxiJb8WPH4orejuy0GV9HH8B1fB6L9pnxBiAg==",
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -39962,7 +39962,7 @@
         "@react-types/combobox": "^3.11.1",
         "@react-types/shared": "^3.23.1",
         "@stitches/react": "1.3.1-1",
-        "@washingtonpost/wpds-assets": "^2.8.0",
+        "@washingtonpost/wpds-assets": "^2.9.0",
         "match-sorter": "6.3.1",
         "nanoid": "^3.3.4",
         "popper-max-size-modifier": "^0.2.0",
@@ -40008,7 +40008,7 @@
       "version": "2.9.0",
       "license": "MIT",
       "dependencies": {
-        "@washingtonpost/wpds-assets": "^2.8.0",
+        "@washingtonpost/wpds-assets": "^2.9.0",
         "@washingtonpost/wpds-ui-kit": "2.9.0",
         "nanoid": "^3.3.4"
       },
@@ -40017,7 +40017,7 @@
         "typescript": "4.5.5"
       },
       "peerDependencies": {
-        "@washingtonpost/wpds-assets": "^2.8.0",
+        "@washingtonpost/wpds-assets": "^2.9.0",
         "@washingtonpost/wpds-ui-kit": "2.9.0",
         "react": "^18.2.0"
       }
@@ -40044,7 +40044,7 @@
       "version": "2.9.0",
       "license": "MIT",
       "devDependencies": {
-        "@washingtonpost/wpds-assets": "^2.8.0",
+        "@washingtonpost/wpds-assets": "^2.9.0",
         "@washingtonpost/wpds-ui-kit": "2.9.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
   ],
   "dependencies": {
     "@babel/standalone": "^7.17.11",
-    "@washingtonpost/wpds-assets": "^2.8.0",
+    "@washingtonpost/wpds-assets": "^2.9.0",
     "typescript": "4.5.5"
   },
   "scripts": {
@@ -135,7 +135,7 @@
   "prettier": {},
   "packageManager": "npm@10.2.4",
   "overrides": {
-    "@washingtonpost/wpds-assets": "^2.8.0",
+    "@washingtonpost/wpds-assets": "^2.9.0",
     "react-docgen-typescript": "^2.2.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
   ],
   "dependencies": {
     "@babel/standalone": "^7.17.11",
-    "@washingtonpost/wpds-assets": "^2.7.0",
+    "@washingtonpost/wpds-assets": "^2.8.0",
     "typescript": "4.5.5"
   },
   "scripts": {
@@ -135,7 +135,7 @@
   "prettier": {},
   "packageManager": "npm@10.2.4",
   "overrides": {
-    "@washingtonpost/wpds-assets": "^2.7.0",
+    "@washingtonpost/wpds-assets": "^2.8.0",
     "react-docgen-typescript": "^2.2.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -25,7 +25,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "@washingtonpost/wpds-ui-kit": "2.0.0-alpha.10"
+    "@washingtonpost/wpds-ui-kit": "2.9.0"
   },
   "dependencies": {
     "@washingtonpost/wpds-ui-kit": "2.9.0"

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -58,7 +58,7 @@
     "@react-types/combobox": "^3.11.1",
     "@react-types/shared": "^3.23.1",
     "@stitches/react": "1.3.1-1",
-    "@washingtonpost/wpds-assets": "^2.8.0",
+    "@washingtonpost/wpds-assets": "^2.9.0",
     "match-sorter": "6.3.1",
     "nanoid": "^3.3.4",
     "popper-max-size-modifier": "^0.2.0",

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -58,7 +58,7 @@
     "@react-types/combobox": "^3.11.1",
     "@react-types/shared": "^3.23.1",
     "@stitches/react": "1.3.1-1",
-    "@washingtonpost/wpds-assets": "^2.7.0",
+    "@washingtonpost/wpds-assets": "^2.8.0",
     "match-sorter": "6.3.1",
     "nanoid": "^3.3.4",
     "popper-max-size-modifier": "^0.2.0",

--- a/packages/kitchen-sink/package.json
+++ b/packages/kitchen-sink/package.json
@@ -36,12 +36,12 @@
     "typescript": "4.5.5"
   },
   "peerDependencies": {
-    "@washingtonpost/wpds-assets": "^2.7.0",
-    "@washingtonpost/wpds-ui-kit": "2.1.0",
+    "@washingtonpost/wpds-assets": "^2.8.0",
+    "@washingtonpost/wpds-ui-kit": "2.9.0",
     "react": "^18.2.0"
   },
   "dependencies": {
-    "@washingtonpost/wpds-assets": "^2.7.0",
+    "@washingtonpost/wpds-assets": "^2.8.0",
     "@washingtonpost/wpds-ui-kit": "2.9.0",
     "nanoid": "^3.3.4"
   },

--- a/packages/kitchen-sink/package.json
+++ b/packages/kitchen-sink/package.json
@@ -36,12 +36,12 @@
     "typescript": "4.5.5"
   },
   "peerDependencies": {
-    "@washingtonpost/wpds-assets": "^2.8.0",
+    "@washingtonpost/wpds-assets": "^2.9.0",
     "@washingtonpost/wpds-ui-kit": "2.9.0",
     "react": "^18.2.0"
   },
   "dependencies": {
-    "@washingtonpost/wpds-assets": "^2.8.0",
+    "@washingtonpost/wpds-assets": "^2.9.0",
     "@washingtonpost/wpds-ui-kit": "2.9.0",
     "nanoid": "^3.3.4"
   },

--- a/packages/tailwind-theme/package.json
+++ b/packages/tailwind-theme/package.json
@@ -17,7 +17,7 @@
     "build": "node script/create-theme.js"
   },
   "peerDependencies": {
-    "@washingtonpost/wpds-ui-kit": "2.0.0-alpha.10"
+    "@washingtonpost/wpds-ui-kit": "2.9.0"
   },
   "dependencies": {
     "@washingtonpost/wpds-ui-kit": "2.9.0"

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -26,7 +26,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@washingtonpost/wpds-assets": "^2.8.0",
+    "@washingtonpost/wpds-assets": "^2.9.0",
     "@washingtonpost/wpds-ui-kit": "2.9.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -26,7 +26,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@washingtonpost/wpds-assets": "^2.7.0",
+    "@washingtonpost/wpds-assets": "^2.8.0",
     "@washingtonpost/wpds-ui-kit": "2.9.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"


### PR DESCRIPTION
## What I did

updates the washingtonpost logo https://github.com/washingtonpost/wpds-assets-manager/pull/220/files#diff-c40429ccb8bf629122e52f1105ff8c28653a7cb36c337d238c6f63450e8a3b36 

test page

https://wpds-ui-kit-git-bump-kit.preview.now.washingtonpost.com/foundations/logos

scroll to washingtonpost logo (first one) 
![CleanShot 2024-12-10 at 12 31 30@2x](https://github.com/user-attachments/assets/142239e0-2f70-4caa-847f-65f7858b9251)

toggle theme - logo color should switch back and forth

<!--
  Explain the **motivation** for making this change. What existing problem does the pull request solve? Please be as detailed as possible.
-->
