### PR TITLE
Input search fixes

### DIFF
--- a/build.washingtonpost.com/components/Markdown/Examples/IconSamples.jsx
+++ b/build.washingtonpost.com/components/Markdown/Examples/IconSamples.jsx
@@ -18,163 +18,163 @@ import { logoList } from "./LogoSamples";
  */
 
 const SuccessToast = ({ Name }) => {
-	return (
-		<AlertBanner.Root variant="success">
-			<AlertBanner.Content css={{ minWidth: 250, paddingRight: "$050" }}>
-				<b>Copied: </b>
-				<Box as="span" css={{ fontSize: 16 }}>
-					Import statement for{" "}
-					<Box as="i" css={{ textTransform: "capitalize" }}>
-						{Name}
-					</Box>
-				</Box>
-			</AlertBanner.Content>
-		</AlertBanner.Root>
-	);
+  return (
+    <AlertBanner.Root variant="success">
+      <AlertBanner.Content css={{ minWidth: 250, paddingRight: "$050" }}>
+        <b>Copied: </b>
+        <Box as="span" css={{ fontSize: 16 }}>
+          Import statement for{" "}
+          <Box as="i" css={{ textTransform: "capitalize" }}>
+            {Name}
+          </Box>
+        </Box>
+      </AlertBanner.Content>
+    </AlertBanner.Root>
+  );
 };
 
 export default function Icons({ data }) {
-	const [controlledValue, setControlledValue] = useState("");
+  const [controlledValue, setControlledValue] = useState("");
 
-	useEffect(() => {
-		// if on window and has search query
-		if (typeof window !== "undefined" && window.location.search) {
-			const search = new URLSearchParams(window.location.search).get("search");
-			setControlledValue(search);
-		}
-	}, []);
+  useEffect(() => {
+    // if on window and has search query
+    if (typeof window !== "undefined" && window.location.search) {
+      const search = new URLSearchParams(window.location.search).get("search");
+      setControlledValue(search);
+    }
+  }, []);
 
-	// when search query changes
-	useEffect(() => {
-		if (controlledValue) {
-			// debounce search
-			const timeout = setTimeout(() => {
-				handleChange({ target: { value: controlledValue } });
+  // when search query changes
+  useEffect(() => {
+    if (controlledValue) {
+      // debounce search
+      const timeout = setTimeout(() => {
+        handleChange({ target: { value: controlledValue } });
 
-				// push search query to url
-				if (typeof window !== "undefined") {
-					window.history.pushState(
-						{},
-						"",
-						`${window.location.pathname}?search=${controlledValue}`,
-					);
-				}
-			}, 300);
+        // push search query to url
+        if (typeof window !== "undefined") {
+          window.history.pushState(
+            {},
+            "",
+            `${window.location.pathname}?search=${controlledValue}`
+          );
+        }
+      }, 300);
 
-			return () => clearTimeout(timeout);
-		}
-	}, [controlledValue]);
+      return () => clearTimeout(timeout);
+    }
+  }, [controlledValue]);
 
-	const fuse = new Fuse(data, {
-		keys: ["name", "description"],
-		threshold: 0.1,
-	});
+  const fuse = new Fuse(data, {
+    keys: ["name", "description"],
+    threshold: 0.1,
+  });
 
-	const [ExampleToCopy, setExampleToCopy] = useState(null);
-	const [Name, setName] = useState("");
-	const [Filter, setFilter] = useState([]);
+  const [ExampleToCopy, setExampleToCopy] = useState(null);
+  const [Name, setName] = useState("");
+  const [Filter, setFilter] = useState([]);
 
-	useEffect(() => {
-		if (ExampleToCopy) {
-			window.navigator.clipboard.writeText(ExampleToCopy);
+  useEffect(() => {
+    if (ExampleToCopy) {
+      window.navigator.clipboard.writeText(ExampleToCopy);
 
-			toast(<SuccessToast Name={Name}/>, {
-				position: "top-center",
-				closeButton: false,
-				autoClose: 2000,
-				hideProgressBar: true,
-				draggable: false,
-				onClose: () => {
-					setName(null);
-				},
-			});
-		}
-	}, [ExampleToCopy, Name]);
+      toast(<SuccessToast Name={Name} />, {
+        position: "top-center",
+        closeButton: false,
+        autoClose: 2000,
+        hideProgressBar: true,
+        draggable: false,
+        onClose: () => {
+          setName(null);
+        },
+      });
+    }
+  }, [ExampleToCopy, Name]);
 
-	function setVariables(example, Name) {
-		setName(Name);
-		setExampleToCopy(example);
-	}
+  function setVariables(example, Name) {
+    setName(Name);
+    setExampleToCopy(example);
+  }
 
-	function handleChange(e) {
-		const value = e.target.value;
+  function handleChange(e) {
+    const value = e.target.value;
 
-		setControlledValue(value);
+    setControlledValue(value);
 
-		const result = fuse.search(value);
-		setFilter(result);
-	}
+    const result = fuse.search(value);
+    setFilter(result);
+  }
 
-	const GetIcons = () => {
-		let list;
+  const GetIcons = () => {
+    let list;
 
-		if (Filter.length === 0) {
-			list = Object.keys(AllAssets).filter(
-				(asset) => !logoList.includes(paramCase(asset)),
-			);
-		} else {
-			list = Filter.map((filtered) =>
-				pascalCase(filtered.item.name).replace("15", "Svg15"),
-			);
-		}
+    if (Filter.length === 0) {
+      list = Object.keys(AllAssets).filter(
+        (asset) => !logoList.includes(paramCase(asset))
+      );
+    } else {
+      list = Filter.map((filtered) =>
+        pascalCase(filtered.item.name).replace("15", "Svg15")
+      );
+    }
 
-		return list.map((Asset, i) => {
-			const Sample = AllAssets[Asset];
-			if (!Sample) {
-				return;
-			}
-			const componentName = paramCase(Asset);
+    return list.map((Asset, i) => {
+      const Sample = AllAssets[Asset];
+      if (!Sample) {
+        return;
+      }
+      const componentName = paramCase(Asset);
 
-			const importExample = `import { ${Asset} } from "@washingtonpost/wpds-assets";`;
+      const importExample = `import { ${Asset} } from "@washingtonpost/wpds-assets";`;
 
-			return (
-				<MDXStyling.Cell key={i}>
-					<Box
-						as="button"
-						onClick={() => setVariables(importExample, componentName)}
-						css={{
-							display: "flex",
-							width: "100%",
-							flexDirection: "column",
-							alignItems: "center",
-							justifyContent: "center",
-							cursor: "pointer",
-							gap: "$075",
-							border: "none",
-							"&:hover": { opacity: 0.5 },
-							backgroundColor: theme.colors.gray500,
-							padding: theme.space[100],
-							color: "$primary",
-						}}
-					>
-						<Icon size="$150">
-							<Sample />
-						</Icon>
-						<Box as="span">{componentName}</Box>
-					</Box>
-				</MDXStyling.Cell>
-			);
-		});
-	};
+      return (
+        <MDXStyling.Cell key={i}>
+          <Box
+            as="button"
+            onClick={() => setVariables(importExample, componentName)}
+            css={{
+              display: "flex",
+              width: "100%",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              cursor: "pointer",
+              gap: "$075",
+              border: "none",
+              "&:hover": { opacity: 0.5 },
+              backgroundColor: theme.colors.gray500,
+              padding: theme.space[100],
+              color: "$primary",
+            }}
+          >
+            <Icon size="$150">
+              <Sample />
+            </Icon>
+            <Box as="span">{componentName}</Box>
+          </Box>
+        </MDXStyling.Cell>
+      );
+    });
+  };
 
-	return (
-		<>
-			<Box css={{ marginBottom: "$050" }}>
-				<InputText
-					onChange={handleChange}
-					label="Search"
-					icon="right"
-					value={controlledValue}
-				>
-					<Icon label="">
-						<Search />
-					</Icon>
-				</InputText>
-			</Box>
+  return (
+    <>
+      <Box css={{ marginBottom: "$050" }}>
+        <InputText
+          onChange={handleChange}
+          label="Search"
+          icon="right"
+          value={controlledValue}
+        >
+          <Icon label="">
+            <Search />
+          </Icon>
+        </InputText>
+      </Box>
 
-			<Grid maxSize={"150px"}>
-				<GetIcons />
-			</Grid>
-		</>
-	);
+      <Grid maxSize={"150px"}>
+        <GetIcons />
+      </Grid>
+    </>
+  );
 }

--- a/build.washingtonpost.com/docs/components/input-search.mdx
+++ b/build.washingtonpost.com/docs/components/input-search.mdx
@@ -563,9 +563,18 @@ export default function Example() {
   const [term, setTerm] = useState("");
   const results = searchCities(term);
 
+  const [selected, setSelected] = useState("");
+
   return (
     <Box css={{ width: "300px", height: "340px" }}>
-      <InputSearch.Root aria-label="Example-Search" openOnFocus>
+      <Box css={{ marginBlockEnd: "$100" }}>
+        <strong>Selected value:</strong> {selected}
+      </Box>
+      <InputSearch.Root
+        aria-label="Example-Search"
+        openOnFocus
+        onSelect={(value) => setSelected(value)}
+      >
         <InputSearch.Input
           name="city"
           id="city"

--- a/packages/kit/src/input-search/InputSearchInput.tsx
+++ b/packages/kit/src/input-search/InputSearchInput.tsx
@@ -62,11 +62,24 @@ export const InputSearchInput = React.forwardRef<
       }
     }, [state.selectionManager.focusedKey, setTempText]);
 
-    if (value) {
+    if (value !== undefined && value !== null) {
       inputProps.value = value;
     }
+
     if (autocomplete && withKeyboard.current) {
       inputProps.value = tempText;
+    }
+
+    const [, setRerender] = React.useState(false);
+    if (!inputProps.value && inputRef.current) {
+      const el = inputRef.current as HTMLInputElement;
+      if (el.value) {
+        // if a controlled input is passed an empty value,
+        // an extra render is needed to reset the input's internal state
+        requestAnimationFrame(() => {
+          setRerender((prev) => !prev);
+        });
+      }
     }
 
     const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {

--- a/packages/kit/src/input-search/InputSearchListItem.tsx
+++ b/packages/kit/src/input-search/InputSearchListItem.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Item } from "react-stately";
 import { useOption } from "react-aria";
 import { styled, theme } from "../theme";
+import { InputSearchContext } from "./InputSearchRoot";
 
 import type { Node, ListState, ComboBoxState } from "react-stately";
 
@@ -75,6 +76,24 @@ interface ListItemProps {
 }
 
 export const ListItem = ({ item, state }: ListItemProps) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { children, textValue, disabled, ...itemProps } = item.props;
+
+  const { setDisabledKeys } = React.useContext(InputSearchContext);
+  React.useEffect(() => {
+    if (disabled && !state.disabledKeys.has(item.key)) {
+      setDisabledKeys((prev) => {
+        if (prev) {
+          const next = new Set(prev);
+          next.add(item.key);
+          return next;
+        } else {
+          return new Set([item.key]);
+        }
+      });
+    }
+  }, [disabled, setDisabledKeys, state.disabledKeys]);
+
   const ref = React.useRef<HTMLLIElement>(null);
   const { optionProps, isDisabled, isSelected, isFocused } = useOption(
     {
@@ -96,9 +115,6 @@ export const ListItem = ({ item, state }: ListItemProps) => {
       match ? `<mark>${match}</mark>` : ""
     );
   }
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { children, textValue, ...itemProps } = item.props;
 
   return (
     <StyledListItem

--- a/packages/kit/src/input-search/InputSearchListItem.tsx
+++ b/packages/kit/src/input-search/InputSearchListItem.tsx
@@ -97,8 +97,11 @@ export const ListItem = ({ item, state }: ListItemProps) => {
     );
   }
 
+  const { children, textValue, ...itemProps } = item.props;
+
   return (
     <StyledListItem
+      {...itemProps}
       {...optionProps}
       ref={ref}
       selected={isSelected}

--- a/packages/kit/src/input-search/InputSearchListItem.tsx
+++ b/packages/kit/src/input-search/InputSearchListItem.tsx
@@ -85,10 +85,15 @@ export const ListItem = ({ item, state }: ListItemProps) => {
   );
 
   let highlighted;
+
+  const escape = (string) => {
+    return string.replace(/[.*+\-?^${}()|[\]\\]/g, "\\$&");
+  };
+
   if (typeof item.rendered === "string") {
-    highlighted = item.rendered.replace(
-      new RegExp((state as ComboBoxState<object>).inputValue, "gi"),
-      (match) => (match ? `<mark>${match}</mark>` : "")
+    const val = escape((state as ComboBoxState<object>).inputValue);
+    highlighted = item.rendered.replace(new RegExp(val, "gi"), (match) =>
+      match ? `<mark>${match}</mark>` : ""
     );
   }
 

--- a/packages/kit/src/input-search/InputSearchListItem.tsx
+++ b/packages/kit/src/input-search/InputSearchListItem.tsx
@@ -97,6 +97,7 @@ export const ListItem = ({ item, state }: ListItemProps) => {
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { children, textValue, ...itemProps } = item.props;
 
   return (

--- a/packages/kit/src/input-search/InputSearchRoot.tsx
+++ b/packages/kit/src/input-search/InputSearchRoot.tsx
@@ -5,7 +5,7 @@ import { useComboBox } from "react-aria";
 import { styled, theme } from "../theme";
 
 import type * as WPDS from "../theme";
-import type { ComboBoxState } from "react-stately";
+import type { ComboBoxState, Key } from "react-stately";
 import type { AriaListBoxOptions } from "react-aria";
 import type { CollectionChildren } from "@react-types/shared";
 
@@ -19,6 +19,9 @@ type InputSearchContextProps = {
   listBoxProps: AriaListBoxOptions<object>;
   setCollectionChildren: React.Dispatch<
     React.SetStateAction<CollectionChildren<object> | undefined>
+  >;
+  setDisabledKeys: React.Dispatch<
+    React.SetStateAction<Iterable<Key> | undefined>
   >;
   isDisabled?: boolean;
   setUsePortal: React.Dispatch<React.SetStateAction<boolean | undefined>>;
@@ -76,9 +79,11 @@ export const InputSearchRoot = ({
 }: InputSearchRootProps) => {
   const [collectionChildren, setCollectionChildren] =
     React.useState<CollectionChildren<object>>();
+  const [disabledKeys, setDisabledKeys] = React.useState<Iterable<Key>>();
 
   const state = useComboBoxState({
     children: collectionChildren,
+    disabledKeys,
     allowsCustomValue: true,
     allowsEmptyCollection: true,
     menuTrigger: openOnFocus ? "focus" : "input",
@@ -132,6 +137,7 @@ export const InputSearchRoot = ({
         inputProps,
         listBoxProps,
         setCollectionChildren,
+        setDisabledKeys,
         setUsePortal,
         setPortalDomNode,
         isDisabled: disabled,

--- a/packages/kit/src/input-search/play.stories.tsx
+++ b/packages/kit/src/input-search/play.stories.tsx
@@ -192,6 +192,34 @@ export const Grouping = {
   },
 };
 
+const DisabledTemplate: StoryFn<typeof InputSearch.Root> = (args) => {
+  return (
+    <Box css={{ width: "275px", height: "340px" }}>
+      <InputSearch.Root {...args} aria-label="Example-Search" openOnFocus>
+        <InputSearch.Input name="fruit" id="fruit" />
+        <InputSearch.Popover>
+          <InputSearch.List>
+            <InputSearch.ListItem value="Apple" />
+            <InputSearch.ListItem value="Banana" disabled />
+            <InputSearch.ListItem value="Orange" />
+            <InputSearch.ListItem value="Kiwi" />
+            <InputSearch.ListItem value="Pineapple" />
+          </InputSearch.List>
+        </InputSearch.Popover>
+      </InputSearch.Root>
+    </Box>
+  );
+};
+
+export const Disabled = {
+  render: DisabledTemplate,
+  args: {},
+
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+};
+
 const ScrollTemplate: StoryFn<typeof InputSearch.Root> = (args) => {
   return (
     <Box css={{ width: "275px", height: "340px", marginBlockStart: "700px" }}>

--- a/packages/kit/src/input-search/play.stories.tsx
+++ b/packages/kit/src/input-search/play.stories.tsx
@@ -223,34 +223,44 @@ export const Scroll = {
 const ControlledTemplate: StoryFn<typeof InputSearch.Root> = (args) => {
   const [term, setTerm] = useState("");
   return (
-    <Box css={{ width: "275px" }}>
-      <InputSearch.Root
-        {...args}
-        aria-label="Example-Search"
-        openOnFocus
-        onSelect={(value) => {
-          setTerm(value);
+    <>
+      <button
+        onClick={() => {
+          setTerm("");
         }}
       >
-        <InputSearch.Input
-          name="fruit"
-          id="fruit"
-          value={term}
-          onChange={(event) => {
-            setTerm(event.target.value);
+        External Clear
+      </button>
+      <br />
+      <Box css={{ width: "275px" }}>
+        <InputSearch.Root
+          {...args}
+          aria-label="Example-Search"
+          openOnFocus
+          onSelect={(value) => {
+            setTerm(value);
           }}
-        />
-        <InputSearch.Popover>
-          <InputSearch.List>
-            <InputSearch.ListItem value="Apple" />
-            <InputSearch.ListItem value="Banana" />
-            <InputSearch.ListItem value="Orange" />
-            <InputSearch.ListItem value="Kiwi" />
-            <InputSearch.ListItem value="Pineapple" />
-          </InputSearch.List>
-        </InputSearch.Popover>
-      </InputSearch.Root>
-    </Box>
+        >
+          <InputSearch.Input
+            name="fruit"
+            id="fruit"
+            value={term}
+            onChange={(event) => {
+              setTerm(event.target.value);
+            }}
+          />
+          <InputSearch.Popover>
+            <InputSearch.List>
+              <InputSearch.ListItem value="Apple" />
+              <InputSearch.ListItem value="Banana" />
+              <InputSearch.ListItem value="Orange" />
+              <InputSearch.ListItem value="Kiwi" />
+              <InputSearch.ListItem value="Pineapple" />
+            </InputSearch.List>
+          </InputSearch.Popover>
+        </InputSearch.Root>
+      </Box>
+    </>
   );
 };
 
@@ -298,7 +308,7 @@ export const ControlledKeyboardInteractions = {
 
   play: async () => {
     const input = await screen.findByLabelText("Search");
-    await userEvent.type(input, "app", {
+    await userEvent.type(input, "test", {
       delay: 100,
     });
     await userEvent.keyboard("[ArrowDown]");
@@ -310,5 +320,14 @@ export const ControlledKeyboardInteractions = {
     const clearButton = await screen.findByText("Clear");
     await userEvent.click(clearButton);
     await expect(input).toHaveDisplayValue("");
+    await userEvent.type(input, "test", {
+      delay: 100,
+    });
+    await userEvent.keyboard("[ArrowDown]");
+    await expect(input).toHaveDisplayValue("Apple");
+    const externalClearButton = await screen.findByText("External Clear");
+    await userEvent.click(externalClearButton);
+    await expect(input).toHaveDisplayValue("");
+    //
   },
 };


### PR DESCRIPTION
## What I did

This PR consolidates several fixes to InputSearch that have been reported over the past few weeks

1. CFE-296 To sanitize input and prevent a regular expression error
    Enter ( in the [input](https://wpds-ui-kit-storybook-git-input-search-fixes.preview.now.washingtonpost.com/?path=/story/inputsearch--play) and not get JS errors
3. CFE-344 Externally clearing when the input is controlled
  clear input text in [controlled example](https://wpds-ui-kit-storybook-git-input-search-fixes.preview.now.washingtonpost.com/?path=/story/inputsearch--controlled) with external button
4. CFE-345 To honor the `disabled` prop in list items
   new [disabled story](https://wpds-ui-kit-storybook-git-input-search-fixes.preview.now.washingtonpost.com/?path=/story/inputsearch--disabled)
5. CFE-346 To honor the `css` prop in list items
    Style list items in [playroom](https://wpds-ui-qnot2db7s.preview.now.washingtonpost.com/playroom?edit=1&code=KYDwDg9gTgLgBAE2AMwIYFcA29noHYDGMAlhHnAKIioC2YmwAFAJRwDeAUHHAWQM7wCxEsD5wAvHADaXbuzh5awAFxwARAEEYmVHhio1AGjgDUMFeoDiwaAHNiBuAF9Ds7mwVLVm9AOJ4jE31zbwAVUFQ%2BNWdXOXlFGgs1ACEIATJA0xD1AFlIvlQCAAtfYBgYKJi3eK91AGEi1ChMCHLgTOCkgDloGCK4OqaITH9HF2qPBKSG4gJUWwgOsySASUwRvAhiSvG4ydq1ABFUdcil7LVw6h3YuX3E70PgPAA3YChz6eHoVARFqr2nge6ieMCgWxgn28OVmRWItl00V2dyBSQAEhBfDAMsYskkrmcASipt4ADKROAANWACKiuM63i6wBevzGt3cqOhDhoxCh6gAYi0oMQEGyJpz1F1IkUXsR1u16csws88KI%2BMB2kSOSTJcAAO5wADyzWAujpQSV6lJmO2DkUSPZNWBaiZBoAmtAANZ8l36uAeqDerVOpIABThOiQmDAcIMiouoZVfAAnpgWXgHA7xTq1OGIM9iCAfRphQAvMhiwE50O9HR4BA%2B400jLB%2B5JADKujgh2IzZ9gxGyGgGcrxIOnfI-KguiEfF4-ZOxCHUBHWar49N5QYPoA6tL-LZsQFWxK1Hu%2BHC8IecRaLocAHR1e9ruAAXQA3BxZLhCCQyCZTSgYo6mEXs%2BEYcwoBoVhODiJc4Ag94aAkcRJDUNQYOqbgoDKdAV0-OInGqHCYDw8ghBEPh72QOVIMYLCEIo5NWHEAA%2BBjuCY%2B8pnvbFrT1d5BnVFh738AhMHQJBwMgmheIgfjBMiJhmFYAAfVSOJ4YRk3vPE5IUqAhOU0TCAkqTEKg-SIAEwylJYZhqmYAjnC-Tj%2BHgKQZNxMpwig18JDgUp206Rh0Kc2ReDwAQ4BwvgsAqAL1SaYDQNECzoM-WQSLIhDqgAHlSEAeD4PhxDYDw9RFPpvAAZgABjqsAi2MIpgHhIoYFqgAWRqi2cJx2Libg8pWPAwHQGB20A4p7wAJQgVo4CaBwAFodAAI2ATBxDUKhaHoYAVqm5KimiCAwGeQ08H5CACF8QahuG0bxsm6ainvZ6Js07gph2pi1G%2BuART%2B7SAceuIyAaXRbGAMrGGZZ4YBY1j2EB7h1RgXyaHht49F4poYZge8WQk4BwvBuQnCIinuAwbFeDoBhzDKtBMHVanwYAegex62Fi%2BKxAAMkF3KabgEaxom46gPemtIDeKAeZpvnRAF%2B8GCvPo4BRuq4AAflFsW5All7pZm0lthgJWjfYfnsComhUDARhGCY5HDZtuITalt77wtgQVnMGg0Zpz1gGTMqAAMABI2C4ni%2BOsxThOYFw4Fjri9MTmyjJYJxI45z2hpJ9BYbYGO4%2B07ilDTjOq7xfPC6LuQCBKsq2HWwpPVscF8AQOpvigbwe41AIqZDx7uYnuQVKbsW8s5z7XpOv3Let8HWFUeii%2B95eZfvCg6BgZNguWOAp5t1PAYXpezdl86IAV9fuCvx6b8lveZvm1olYXwqHvCk4IAA&isGuide=none)
7. CFE-347 To have an example in the documentation using the `onSelect` callback
   see new [Selected example](https://wpds-ui-qnot2db7s.preview.now.washingtonpost.com/components/input-search#Selected)
