### PR TITLE
fix: update robots meta tag in non prod builds

### DIFF
--- a/build.washingtonpost.com/components/next-seo/defaultSeo.tsx
+++ b/build.washingtonpost.com/components/next-seo/defaultSeo.tsx
@@ -33,6 +33,8 @@ interface DefaultSeoProps {
 }
 
 export const DefaultSeo: React.FC<DefaultSeoProps> = ({ seoConfig }) => {
+  const env = process.env.VERCEL_ENV || "";
+
   return (
     <Head>
       <title>{seoConfig.defaultTitle}</title>
@@ -54,7 +56,12 @@ export const DefaultSeo: React.FC<DefaultSeoProps> = ({ seoConfig }) => {
         content={seoConfig.twitter.description}
       />
       <meta name="twitter:creator" content={seoConfig.twitter.handle} />
-      <meta name="robots" content="index,follow" />
+      <meta
+        name="robots"
+        content={`${
+          env === "production" ? "index,follow" : "noindex, nofollow"
+        }`}
+      />
     </Head>
   );
 };


### PR DESCRIPTION
## What I did
Added `noindex,nofollow` to robots meta tag for non-production pages to avoid having preview/non-prod pages picked up search engines.

### Test
- Go to [build page](https://wpds-ui-kit-git-cfe-356-robots-metatag.preview.now.washingtonpost.com/)
- Confirm you see `noindex,nofollow` in robots meta tag
