### PR TITLE
fix: allow for reselecting the last selection of InputSearch if cleared. Trigger InputSearch onSelect callback when selection is cleared.

### DIFF
--- a/build.washingtonpost.com/components/Markdown/Examples/Breakpoints.jsx
+++ b/build.washingtonpost.com/components/Markdown/Examples/Breakpoints.jsx
@@ -21,7 +21,7 @@ const Ruler = styled("div", {
 const Body = styled("div", {
   paddingBlock: "1px",
   fontFamily: theme.fonts.meta,
-  placeItems: "left"
+  placeItems: "left",
 });
 
 const PointsList = styled("ul", {

--- a/packages/kit/src/input-search/InputSearchInput.tsx
+++ b/packages/kit/src/input-search/InputSearchInput.tsx
@@ -24,6 +24,7 @@ export const InputSearchInput = React.forwardRef<
     {
       label = "Search",
       autocomplete = true,
+      autoComplete = "off",
       id,
       value,
       ...rest
@@ -46,6 +47,13 @@ export const InputSearchInput = React.forwardRef<
       if (inputProps.onChange) inputProps.onChange(event);
     };
 
+    React.useEffect(() => {
+      // allow for external changes for controlled inputs
+      if (value !== undefined && value !== null && value !== inputProps.value) {
+        state.setInputValue(value);
+      }
+    }, [value, inputProps.value, state]);
+
     const [tempText, setTempText] = React.useState<string>();
     const withKeyboard = React.useRef(false);
     React.useEffect(() => {
@@ -62,24 +70,8 @@ export const InputSearchInput = React.forwardRef<
       }
     }, [state.selectionManager.focusedKey, setTempText]);
 
-    if (value !== undefined && value !== null) {
-      inputProps.value = value;
-    }
-
     if (autocomplete && withKeyboard.current) {
       inputProps.value = tempText;
-    }
-
-    const [, setRerender] = React.useState(false);
-    if (!inputProps.value && inputRef.current) {
-      const el = inputRef.current as HTMLInputElement;
-      if (el.value) {
-        // if a controlled input is passed an empty value,
-        // an extra render is needed to reset the input's internal state
-        requestAnimationFrame(() => {
-          setRerender((prev) => !prev);
-        });
-      }
     }
 
     const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -111,6 +103,7 @@ export const InputSearchInput = React.forwardRef<
         onChange={handleChange}
         onKeyDown={handleKeyDown}
         onKeyUp={handleKeyUp}
+        autoComplete={autoComplete}
       />
     );
   }

--- a/packages/kit/src/input-search/InputSearchRoot.tsx
+++ b/packages/kit/src/input-search/InputSearchRoot.tsx
@@ -107,14 +107,16 @@ export const InputSearchRoot = ({
 
   const prevSelectedKey = React.useRef(state.selectedKey);
   React.useEffect(() => {
-    if (
-      state.selectedItem &&
-      onSelect &&
-      prevSelectedKey.current !== state.selectedKey
-    ) {
-      onSelect(
-        state.selectedItem.textValue || (state.selectedItem.rendered as string)
-      );
+    if (!onSelect) return;
+    if (prevSelectedKey.current !== state.selectedKey) {
+      if (state.selectedItem) {
+        onSelect(
+          state.selectedItem.textValue ||
+            (state.selectedItem.rendered as string)
+        );
+      } else if (state.selectedItem === null) {
+        onSelect("");
+      }
       prevSelectedKey.current = state.selectedKey;
     }
   }, [state.selectedItem, onSelect]);

--- a/packages/kit/src/input-search/play.stories.tsx
+++ b/packages/kit/src/input-search/play.stories.tsx
@@ -7,6 +7,7 @@ import { InputSearch } from "./";
 import { cities } from "./cities";
 
 import type { StoryFn } from "@storybook/react";
+import exp from "constants";
 
 export default {
   title: "InputSearch",
@@ -356,6 +357,11 @@ export const ControlledKeyboardInteractions = {
     const externalClearButton = await screen.findByText("External Clear");
     await userEvent.click(externalClearButton);
     await expect(input).toHaveDisplayValue("");
+    await userEvent.click(input);
+    await expect(input).toHaveFocus();
+    const appleOption = await screen.findByRole("option", { name: "Apple" });
+    await userEvent.click(appleOption);
+    await expect(input).toHaveDisplayValue("Apple");
     //
   },
 };

--- a/packages/kit/src/input-search/play.stories.tsx
+++ b/packages/kit/src/input-search/play.stories.tsx
@@ -1,13 +1,12 @@
 import React, { useMemo, useState, useEffect } from "react";
 import { screen, userEvent } from "@storybook/testing-library";
-import { expect } from "@storybook/jest";
+import { expect, jest } from "@storybook/jest";
 import { Box } from "../box";
 import { matchSorter } from "match-sorter";
 import { InputSearch } from "./";
 import { cities } from "./cities";
 
 import type { StoryFn } from "@storybook/react";
-import exp from "constants";
 
 export default {
   title: "InputSearch",
@@ -302,9 +301,13 @@ export const Controlled = {
   },
 };
 
-const InteractionsTemplate: StoryFn<typeof InputSearch.Root> = () => (
+const InteractionsTemplate: StoryFn<typeof InputSearch.Root> = (args) => (
   <Box css={{ width: "275px", height: "340px" }}>
-    <InputSearch.Root aria-label="Example-Search" openOnFocus>
+    <InputSearch.Root
+      aria-label="Example-Search"
+      openOnFocus
+      onSelect={args.onSelect}
+    >
       <InputSearch.Input name="city" id="city" />
       <InputSearch.Popover>
         <InputSearch.List>
@@ -321,14 +324,21 @@ const InteractionsTemplate: StoryFn<typeof InputSearch.Root> = () => (
 
 export const Interactions = {
   render: InteractionsTemplate,
-
-  play: async () => {
+  args: {
+    onSelect: jest.fn(),
+  },
+  play: async ({ args }) => {
     const input = await screen.findByLabelText("Search");
     await userEvent.type(input, "app", {
       delay: 100,
     });
     await userEvent.keyboard("[ArrowDown]");
     await expect(input).toHaveDisplayValue("Apple");
+    await userEvent.keyboard("[Enter]");
+    await expect(args.onSelect).toHaveBeenCalledWith("Apple");
+    const clearButton = await screen.findByRole("button", { name: "Clear" });
+    await userEvent.click(clearButton);
+    await expect(args.onSelect).toHaveBeenCalledWith("");
   },
 };
 

--- a/packages/kit/src/input-search/play.stories.tsx
+++ b/packages/kit/src/input-search/play.stories.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo, useState, useEffect } from "react";
-import { screen, userEvent } from "@storybook/testing-library";
+import React, { useMemo, useState, useEffect, use } from "react";
+import { screen, userEvent, waitFor } from "@storybook/testing-library";
 import { expect, jest } from "@storybook/jest";
 import { Box } from "../box";
 import { matchSorter } from "match-sorter";
@@ -267,6 +267,8 @@ const ControlledTemplate: StoryFn<typeof InputSearch.Root> = (args) => {
           openOnFocus
           onSelect={(value) => {
             setTerm(value);
+            console.log("onSelect", value);
+            args.onSelect && args.onSelect(value);
           }}
         >
           <InputSearch.Input
@@ -294,8 +296,9 @@ const ControlledTemplate: StoryFn<typeof InputSearch.Root> = (args) => {
 
 export const Controlled = {
   render: ControlledTemplate,
-  args: {},
-
+  args: {
+    onSelect: jest.fn(),
+  },
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -345,7 +348,7 @@ export const Interactions = {
 export const ControlledKeyboardInteractions = {
   render: ControlledTemplate,
 
-  play: async () => {
+  play: async ({ args }) => {
     const input = await screen.findByLabelText("Search");
     await userEvent.type(input, "test", {
       delay: 100,
@@ -356,6 +359,9 @@ export const ControlledKeyboardInteractions = {
     await expect(input).toHaveDisplayValue("Orange");
     await userEvent.keyboard("[Backspace]");
     await expect(input).toHaveDisplayValue("Orang");
+    await userEvent.keyboard("[ArrowUp]");
+    await userEvent.keyboard("[Enter]");
+    await expect(args.onSelect).toHaveBeenCalledWith("Pineapple");
     const clearButton = await screen.findByText("Clear");
     await userEvent.click(clearButton);
     await expect(input).toHaveDisplayValue("");
@@ -372,6 +378,7 @@ export const ControlledKeyboardInteractions = {
     const appleOption = await screen.findByRole("option", { name: "Apple" });
     await userEvent.click(appleOption);
     await expect(input).toHaveDisplayValue("Apple");
+    await expect(args.onSelect).toHaveBeenCalledWith("Apple");
     //
   },
 };


### PR DESCRIPTION
## What I did

This PR  adds code to handle a mismatch of internal and external state when a controlled input is cleared.

In addition, it updates how clearing is handled to ensure onSelect is called.