### PR TITLE
chore: bump @washingtonpost/site-footer version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -387,11 +387,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "build.washingtonpost.com/node_modules/@washingtonpost/front-end-utils": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/front-end-utils/-/front-end-utils-1.2.1.tgz",
-      "integrity": "sha512-iXee84DA+DTzqtwVFTl8YUf6XfKwaEOa0r70WPUMRe97Voc86jqs4vm/KjT00y9g/vOEx3i2Nna9zW2rsNQ77w=="
-    },
     "build.washingtonpost.com/node_modules/@washingtonpost/site-favicons": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@washingtonpost/site-favicons/-/site-favicons-1.1.0.tgz",
@@ -399,48 +394,6 @@
       "peerDependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
-      }
-    },
-    "build.washingtonpost.com/node_modules/@washingtonpost/site-footer": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/site-footer/-/site-footer-1.6.4.tgz",
-      "integrity": "sha512-qgrhOxDnUQFNpPlb4wpcnjbapgAZmCvuuvhq4hz57JxiPmMYxV3K2RbVGSX+Q/pM0vdzOiqZblU7OyauZv/oPQ==",
-      "dependencies": {
-        "@washingtonpost/front-end-utils": "1.2.1",
-        "@washingtonpost/site-user-data": "1.2.3",
-        "@washingtonpost/wpds-ui-kit": "^2.9.0",
-        "swr": "^2.2.0"
-      },
-      "engines": {
-        "node": ">= 12 || >= 14 || >= 16 || >= 18"
-      },
-      "peerDependencies": {
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
-      }
-    },
-    "build.washingtonpost.com/node_modules/@washingtonpost/site-user-data": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/site-user-data/-/site-user-data-1.2.3.tgz",
-      "integrity": "sha512-oX9rAt23NmpMQxhxf6cx6k/ks5U0ORNn2yPVRhF0TJC8uiLXvQMN/VX1A//QINhjlMUjHf5NSihJuAciCxB71Q==",
-      "dependencies": {
-        "@washingtonpost/front-end-utils": "1.2.1",
-        "@washingtonpost/subs-sdk": "2.0.0-react18.29",
-        "react": "^18.2.0"
-      },
-      "engines": {
-        "node": ">= 12 || >= 14 || >= 16 || >= 18"
-      },
-      "peerDependencies": {
-        "react": "^18.2.0"
-      }
-    },
-    "build.washingtonpost.com/node_modules/@washingtonpost/subs-sdk": {
-      "version": "2.0.0-react18.29",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/subs-sdk/-/subs-sdk-2.0.0-react18.29.tgz",
-      "integrity": "sha512-/LzNJJGQ2GvvBaarWnWxASklTk8+s77MA0QcQEZojfZGzWHmZ/h6j3NyxEFMYNFUvByhOyALqObEhB9skuSLXA==",
-      "optionalDependencies": {
-        "@esbuild/linux-x64": "0.20.2"
       }
     },
     "build.washingtonpost.com/node_modules/@washingtonpost/tachyons-css": {
@@ -13511,6 +13464,54 @@
     "node_modules/@washingtonpost/eslint-plugin-wpds": {
       "resolved": "packages/eslint-plugin",
       "link": true
+    },
+    "node_modules/@washingtonpost/front-end-utils": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/front-end-utils/-/front-end-utils-1.2.1.tgz",
+      "integrity": "sha512-iXee84DA+DTzqtwVFTl8YUf6XfKwaEOa0r70WPUMRe97Voc86jqs4vm/KjT00y9g/vOEx3i2Nna9zW2rsNQ77w=="
+    },
+    "node_modules/@washingtonpost/site-footer": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/site-footer/-/site-footer-1.6.7.tgz",
+      "integrity": "sha512-SbocGMTOuehMEFExabqpkKpwU/QWRkmiCsIHUrQKbVsNhVzRRpaxJl8G53CM1gdBLB6F7WEqAla5GJFlzao6NA==",
+      "dependencies": {
+        "@washingtonpost/front-end-utils": "1.2.1",
+        "@washingtonpost/site-user-data": "1.2.3",
+        "@washingtonpost/wpds-assets": "^2.9.0",
+        "@washingtonpost/wpds-ui-kit": "^2.11.0",
+        "swr": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 12 || >= 14 || >= 16 || >= 18"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@washingtonpost/site-user-data": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/site-user-data/-/site-user-data-1.2.3.tgz",
+      "integrity": "sha512-oX9rAt23NmpMQxhxf6cx6k/ks5U0ORNn2yPVRhF0TJC8uiLXvQMN/VX1A//QINhjlMUjHf5NSihJuAciCxB71Q==",
+      "dependencies": {
+        "@washingtonpost/front-end-utils": "1.2.1",
+        "@washingtonpost/subs-sdk": "2.0.0-react18.29",
+        "react": "^18.2.0"
+      },
+      "engines": {
+        "node": ">= 12 || >= 14 || >= 16 || >= 18"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/@washingtonpost/subs-sdk": {
+      "version": "2.0.0-react18.29",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/subs-sdk/-/subs-sdk-2.0.0-react18.29.tgz",
+      "integrity": "sha512-/LzNJJGQ2GvvBaarWnWxASklTk8+s77MA0QcQEZojfZGzWHmZ/h6j3NyxEFMYNFUvByhOyALqObEhB9skuSLXA==",
+      "optionalDependencies": {
+        "@esbuild/linux-x64": "0.20.2"
+      }
     },
     "node_modules/@washingtonpost/wpds-assets": {
       "version": "2.10.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13471,9 +13471,9 @@
       "integrity": "sha512-iXee84DA+DTzqtwVFTl8YUf6XfKwaEOa0r70WPUMRe97Voc86jqs4vm/KjT00y9g/vOEx3i2Nna9zW2rsNQ77w=="
     },
     "node_modules/@washingtonpost/site-footer": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/@washingtonpost/site-footer/-/site-footer-1.6.7.tgz",
-      "integrity": "sha512-SbocGMTOuehMEFExabqpkKpwU/QWRkmiCsIHUrQKbVsNhVzRRpaxJl8G53CM1gdBLB6F7WEqAla5GJFlzao6NA==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@washingtonpost/site-footer/-/site-footer-1.6.8.tgz",
+      "integrity": "sha512-3UX4WgV2uFH2pZajmtPPHclN3z1huWxGtk5k3sJ5Iz3I/CWyIPDLrFhv3EkZ1yPAdugXg8XM8BhM47HPls31zg==",
       "dependencies": {
         "@washingtonpost/front-end-utils": "1.2.1",
         "@washingtonpost/site-user-data": "1.2.3",


### PR DESCRIPTION
## What I did

Updating `package-lock.json` with the latest `@washingtonpost/site-footer` version `1.6.8`.

## Test Instructions
1. Visit https://wpds-ui-kit-git-fix-footer-fouc.preview.now.washingtonpost.com/ and verify footer no longer has gaps and FOUC