### PR TITLE
chore: stack examples at sm breakpoints

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -37,10 +37,8 @@ export const parameters = {
 
 const Panel = styled("div", {
   padding: theme.space[200],
-  marginTop: "-$100",
-  marginBottom: "-$100",
-  width: "50%",
-  minHeight: "100vh",
+  width: "100%",
+  minHeight: "50vh",
   display: "flex",
   flexDirection: "column",
   justifyContent: "center",
@@ -51,6 +49,11 @@ const Panel = styled("div", {
         backgroundColor: theme.colors.gray500,
       },
     },
+  },
+  "@notSm": {
+    minHeight: "100vh",
+    marginTop: "-$100",
+    marginBottom: "-$100",
   },
 });
 
@@ -87,6 +90,10 @@ export const decorators = [
           height: "50%",
           justifyContent: "center",
           alignItems: "center",
+          flexDirection: "column",
+          "@notSm": {
+            flexDirection: "row",
+          },
         }}
       >
         <GlobalStyles>


### PR DESCRIPTION
## What I did

Noticed that it gets super annoying to test (or even look at) our components in mobile break points because of the split light/dark. Changed it so that now on small breakpoints the light/dark containers are stacked instead of next to each other.

Before (@sm breakpoint only)
<img width="428" alt="Screenshot 2025-03-11 at 3 37 40 PM" src="https://github.com/user-attachments/assets/a0632ac2-bf38-4d04-9df2-02b1d3483a24" />

After (@sm breakpoint only)
<img width="495" alt="Screenshot 2025-03-11 at 3 44 53 PM" src="https://github.com/user-attachments/assets/33bc09c0-442a-4a2e-96c6-39625d14b978" />
