### PR TITLE
chore: fix pseudo states not working inside dialog [WE-70]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7024,41 +7024,6 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-dialog": {
-      "version": "1.0.5",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/primitive": "1.0.1",
-        "@radix-ui/react-compose-refs": "1.0.1",
-        "@radix-ui/react-context": "1.0.1",
-        "@radix-ui/react-dismissable-layer": "1.0.5",
-        "@radix-ui/react-focus-guards": "1.0.1",
-        "@radix-ui/react-focus-scope": "1.0.4",
-        "@radix-ui/react-id": "1.0.1",
-        "@radix-ui/react-portal": "1.0.4",
-        "@radix-ui/react-presence": "1.0.1",
-        "@radix-ui/react-primitive": "1.0.3",
-        "@radix-ui/react-slot": "1.0.2",
-        "@radix-ui/react-use-controllable-state": "1.0.1",
-        "aria-hidden": "^1.1.1",
-        "react-remove-scroll": "2.5.5"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0",
-        "react-dom": "^16.8 || ^17.0 || ^18.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-direction": {
       "version": "1.0.1",
       "license": "MIT",
@@ -39804,7 +39769,7 @@
         "@radix-ui/react-accordion": "^1.1.2",
         "@radix-ui/react-avatar": "latest",
         "@radix-ui/react-checkbox": "^1.0.0",
-        "@radix-ui/react-dialog": "^1.0.5",
+        "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-dropdown-menu": "2.0.3",
         "@radix-ui/react-focus-scope": "^1.0.0",
         "@radix-ui/react-label": "^1.0.0",
@@ -40013,6 +39978,63 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "packages/kit/node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.6.tgz",
+      "integrity": "sha512-/IVhJV5AceX620DUJ4uYVMymzsipdKBzo3edo+omeskCKGm9FRHM0ebIdbPnlQVJqyuHbuBltQUOG2mOTq2IYw==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.5",
+        "@radix-ui/react-focus-guards": "1.1.1",
+        "@radix-ui/react-focus-scope": "1.1.2",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-portal": "1.1.4",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-slot": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "packages/kit/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.2.tgz",
+      "integrity": "sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -40249,6 +40271,29 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "packages/kit/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.2.tgz",
+      "integrity": "sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -40,7 +40,7 @@
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-avatar": "latest",
     "@radix-ui/react-checkbox": "^1.0.0",
-    "@radix-ui/react-dialog": "^1.0.5",
+    "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-dropdown-menu": "2.0.3",
     "@radix-ui/react-focus-scope": "^1.0.0",
     "@radix-ui/react-label": "^1.0.0",

--- a/packages/kit/src/dialog/play.stories.tsx
+++ b/packages/kit/src/dialog/play.stories.tsx
@@ -127,7 +127,7 @@ const ComplexTemplate: StoryFn<typeof Dialog.Root> = (args) => {
 
   return (
     <DialogContainer ref={setContainer}>
-      <Dialog.Root defaultOpen>
+      <Dialog.Root {...args} defaultOpen>
         <Dialog.Trigger asChild>
           <Button>Open dialog</Button>
         </Dialog.Trigger>

--- a/packages/kit/src/dialog/play.stories.tsx
+++ b/packages/kit/src/dialog/play.stories.tsx
@@ -3,7 +3,15 @@ import { userEvent, waitFor, within } from "@storybook/testing-library";
 
 import { expect } from "@storybook/jest";
 import { Dialog } from "./Dialog";
-import { Button, styled, theme } from "../";
+import {
+  styled,
+  theme,
+  Box,
+  Button,
+  RadioButton,
+  RadioGroup,
+  Select,
+} from "../";
 
 import type { Meta, StoryFn } from "@storybook/react";
 
@@ -112,6 +120,74 @@ const ContentTemplate: StoryFn<typeof Dialog.Root> = (args) => {
 
 export const Content = {
   render: ContentTemplate,
+};
+
+const ComplexTemplate: StoryFn<typeof Dialog.Root> = (args) => {
+  const [container, setContainer] = React.useState<HTMLDivElement | null>(null);
+
+  return (
+    <DialogContainer ref={setContainer}>
+      <Dialog.Root defaultOpen>
+        <Dialog.Trigger asChild>
+          <Button>Open dialog</Button>
+        </Dialog.Trigger>
+        <Dialog.Portal container={container}>
+          <Dialog.Content height="500px" width="900px">
+            <Dialog.Close />
+            <Dialog.Header>
+              <Dialog.Title>Complex dialog</Dialog.Title>
+            </Dialog.Header>
+            <Dialog.Body>
+              <Box css={{ marginBlockEnd: "$100" }}>
+                <RadioGroup
+                  legend="Label"
+                  name="horizontal"
+                  orientation="horizontal"
+                  variant="primary"
+                >
+                  <RadioButton label="Option" value="opt1" id="opt1" />
+                  <RadioButton label="Option" value="opt2" id="opt2" />
+                  <RadioButton label="Option" value="opt3" id="opt3" />
+                  <RadioButton label="Option" value="opt4" id="opt4" />
+                  <RadioButton label="Option" value="opt5" id="opt5" />
+                  <RadioButton label="Option" value="opt6" id="opt6" />
+                </RadioGroup>
+              </Box>
+              <Box
+                css={{ marginBlockEnd: "$100", display: "flex", gap: "$100" }}
+              >
+                <Box css={{ flex: 1 }}>
+                  <Select.Root>
+                    <Select.Trigger aria-label="Select options">
+                      <Select.Label>Label/Placeholder</Select.Label>
+                      <Select.Value />
+                    </Select.Trigger>
+                    <Select.Content css={{ zIndex: "$offer" }}>
+                      <Select.Item value="op1">Option</Select.Item>
+                      <Select.Item value="op2">Option</Select.Item>
+                      <Select.Item value="op3">Option</Select.Item>
+                      <Select.Item value="op4">Option</Select.Item>
+                      <Select.Item value="op5">Option</Select.Item>
+                    </Select.Content>
+                  </Select.Root>
+                </Box>
+              </Box>
+            </Dialog.Body>
+            <Dialog.Footer>
+              <Dialog.Close asChild>
+                <Button>Cancel</Button>
+              </Dialog.Close>
+              <Button variant="primary">Confirm</Button>
+            </Dialog.Footer>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+    </DialogContainer>
+  );
+};
+
+export const Complex = {
+  render: ComplexTemplate,
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
### What I did
Bumped up radix dialog version
added extra storybook example

### Testing
Check that you can see the pseudo states in select inside the dialog.

https://wpds-ui-kit-storybook-git-fix-select-ps-dialog.preview.now.washingtonpost.com/?path=/story/dialog--complex
https://wpds-docs-git-fix-select-ps-dialog.preview.now.washingtonpost.com/components/dialog

https://arcpublishing.atlassian.net/browse/WE-70

