### PR TITLE
adds cmd k shortcut to doc search

### DIFF
--- a/build.washingtonpost.com/components/Search/SearchInput.jsx
+++ b/build.washingtonpost.com/components/Search/SearchInput.jsx
@@ -134,6 +134,20 @@ export const DocSearch = ({ placeholder = "Search documentation...", maxResults 
     search();
   }, [debouncedSearchTerm, maxResults]);
 
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      if ((event.metaKey || event.ctrlKey) && event.key === 'k') {
+        event.preventDefault();
+        openDialog();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, []);
+
   const handleInputChange = (event) => {
     setSearchTerm(event.target.value);
     if (event.target.value) {


### PR DESCRIPTION
1. https://wpds-docs-git-cmd-k.preview.now.washingtonpost.com/
2. Tap CMD + K
3. Search dialog should open