### PR TITLE
chore: upgrade actions setup node to v4 [WE-138]

### DIFF
--- a/.github/workflows/chromatic-prod.yml
+++ b/.github/workflows/chromatic-prod.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v2.5.1
+      - uses: actions/setup-node@v4.0.0
         with:
           node-version-file: ".nvmrc"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/experimental-release.yml
+++ b/.github/workflows/experimental-release.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v2.5.1
+      - uses: actions/setup-node@v4.0.0
         with:
           node-version-file: ".nvmrc"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/latest-release.yml
+++ b/.github/workflows/latest-release.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v2.5.1
+      - uses: actions/setup-node@v4.0.0
         with:
           node-version-file: ".nvmrc"
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
[WE-138](https://arcpublishing.atlassian.net/browse/WE-138)
Received this error while trying to run the experimental release workflow: `Error: Cache service responded with 422` [Release to Experimental NPM Channel · washingtonpost/wpds-ui-kit@36f2ed6](https://github.com/washingtonpost/wpds-ui-kit/actions/runs/14342008395/job/40203296455) 

Upgrading to `setup-node@v4` should resolve this issue [Errors out on npm cache (no changes, worked fine until now) · Issue #1275 · actions/setup-node](https://github.com/actions/setup-node/issues/1275#issuecomment-2788204086)

[@actions/cache Package Deprecation Notice. Upgrade to the latest `4.0.0` or higher before February 1st 2025 · actions toolkit · Discussion #1890](https://github.com/actions/toolkit/discussions/1890)

## What I did
Upgraded `actions/setup-node@v2.5.1` to `actions/setup-node@v4.0.0`
